### PR TITLE
fix(ci): prevent husky pre-push hook from failing release pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,8 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      HUSKY: '0'
 
     steps:
       - name: Checkout code

--- a/.prettierignore
+++ b/.prettierignore
@@ -32,3 +32,6 @@ Dockerfile
 
 # Git files
 .gitignore
+
+# Auto-generated files
+CHANGELOG.md


### PR DESCRIPTION
## Summary
- Add `CHANGELOG.md` to `.prettierignore` — it's auto-generated by semantic-release and not Prettier-formatted
- Set `HUSKY=0` in the release job — git hooks shouldn't run in CI since the quality-gates job already validates formatting, lint, tests, and build independently

## Root Cause
Release Pipeline run [#24940116512](https://github.com/Integral-X/prismacv-ui/actions/runs/24940116512) failed because semantic-release updated `CHANGELOG.md` then ran `git push --tags`, which triggered the Husky `pre-push` hook. The hook ran `pnpm verify` → `prettier --check .` and flagged the auto-generated `CHANGELOG.md` as unformatted.

## Test plan
- [ ] PR Validation pipeline passes (format, lint, typecheck, test, build)
- [ ] After merge, Release Pipeline completes successfully