### PR TITLE
feat: Complete platform UI - Jobs tracker, Skills assessment, Interview prep

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Navigation', () => {
+  test('homepage should display public navigation links', async ({ page }) => {
+    await page.goto('/');
+
+    // Public nav items should be visible
+    const nav = page.locator('nav');
+    if ((await nav.count()) > 0) {
+      // Check for public links
+      const templateLink = page.getByRole('link', { name: /templates/i });
+      const pricingLink = page.getByRole('link', { name: /pricing/i });
+      const faqLink = page.getByRole('link', { name: /faq/i });
+
+      if ((await templateLink.count()) > 0) {
+        await expect(templateLink.first()).toBeVisible();
+      }
+      if ((await pricingLink.count()) > 0) {
+        await expect(pricingLink.first()).toBeVisible();
+      }
+      if ((await faqLink.count()) > 0) {
+        await expect(faqLink.first()).toBeVisible();
+      }
+    }
+  });
+
+  test('homepage should have login/signup call to action', async ({ page }) => {
+    await page.goto('/');
+
+    // Look for auth-related links
+    const loginLink = page.getByRole('link', { name: /log\s*in|sign\s*in/i });
+    const signupLink = page.getByRole('link', {
+      name: /sign\s*up|get\s*started|register/i,
+    });
+
+    const hasLogin = (await loginLink.count()) > 0;
+    const hasSignup = (await signupLink.count()) > 0;
+
+    // At least one auth CTA should be present
+    expect(hasLogin || hasSignup).toBe(true);
+  });
+
+  test('homepage should load with valid status', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response?.status()).toBe(200);
+  });
+});

--- a/e2e/protected-routes.spec.ts
+++ b/e2e/protected-routes.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Protected Routes', () => {
+  const protectedRoutes = [
+    { path: '/jobs', name: 'Jobs' },
+    { path: '/skills', name: 'Skills' },
+    { path: '/interview', name: 'Interview' },
+    { path: '/dashboard', name: 'Dashboard' },
+  ];
+
+  for (const route of protectedRoutes) {
+    test(`${route.name} page should redirect unauthenticated users to login`, async ({
+      page,
+    }) => {
+      await page.goto(route.path);
+
+      // Should redirect to login
+      await page.waitForURL(/\/login/);
+      expect(page.url()).toContain('/login');
+      expect(page.url()).toContain(
+        `redirect=${encodeURIComponent(route.path)}`
+      );
+    });
+  }
+
+  test('should preserve query params in redirect', async ({ page }) => {
+    await page.goto('/jobs?status=APPLIED');
+
+    await page.waitForURL(/\/login/);
+    const url = new URL(page.url());
+    const redirect = url.searchParams.get('redirect');
+    expect(redirect).toContain('/jobs');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "lucide-react": "^0.564.0",
     "next": "16.1.6",
     "pino": "^10.3.1",
+    "radix-ui": "^1.4.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-hook-form": "^7.71.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       pino:
         specifier: ^10.3.1
         version: 10.3.1
+      radix-ui:
+        specifier: ^1.4.3
+        version: 1.4.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -73,7 +76,7 @@ importers:
         version: 4.3.6
       zustand:
         specifier: ^5.0.11
-        version: 5.0.11(@types/react@19.2.2)(react@19.1.0)
+        version: 5.0.11(@types/react@19.2.2)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0))
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3
@@ -556,105 +559,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -828,28 +815,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -955,8 +938,24 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
+  '@radix-ui/number@1.1.1':
+    resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
+
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-accessible-icon@1.1.7':
+    resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
@@ -971,8 +970,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-alert-dialog@1.1.15':
+    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.7':
+    resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.10':
+    resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1032,6 +1070,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context-menu@2.2.16':
+    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
@@ -1076,6 +1127,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -1087,6 +1151,32 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.7':
     resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-form@0.1.8':
+    resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.15':
+    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1110,6 +1200,84 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.16':
+    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.14':
+    resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.8':
+    resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.3':
+    resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-popover@1.1.15':
@@ -1177,6 +1345,97 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.7':
+    resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-scroll-area@1.2.10':
+    resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.2.6':
+    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.7':
+    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.3.6':
+    resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
@@ -1193,6 +1452,97 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.6':
+    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.15':
+    resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.11':
+    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.10':
+    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.11':
+    resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.1.1':
@@ -1224,6 +1574,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1265,6 +1624,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/rect@1.1.1':
@@ -1384,28 +1756,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -1648,49 +2016,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3392,28 +3752,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -4066,6 +4422,19 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  radix-ui@1.4.3:
+    resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -4779,6 +5148,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -5808,7 +6182,18 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
+  '@radix-ui/number@1.1.1': {}
+
   '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-accessible-icon@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
   '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -5827,9 +6212,45 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-aspect-ratio@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-avatar@1.1.10(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:
@@ -5886,6 +6307,20 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-context@1.1.2(@types/react@19.2.2)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -5933,6 +6368,21 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.2)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -5950,6 +6400,37 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-form@0.1.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-icons@1.3.2(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -5960,6 +6441,117 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-label@2.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.2.2)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-navigation-menu@1.2.14(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-one-time-password-field@0.1.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-password-toggle-field@0.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
   '@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -6031,6 +6623,125 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
+  '@radix-ui/react-progress@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-scroll-area@1.2.10(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-select@2.2.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.2.2)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-slider@1.3.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/number': 1.1.1
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   '@radix-ui/react-slot@1.2.3(@types/react@19.2.2)(react@19.1.0)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
@@ -6044,6 +6755,118 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-toast@1.2.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-toolbar@1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.2)(react@19.1.0)':
     dependencies:
@@ -6073,6 +6896,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.2)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+      use-sync-external-store: 1.6.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.2)(react@19.1.0)':
     dependencies:
       react: 19.1.0
@@ -6098,6 +6928,15 @@ snapshots:
       react: 19.1.0
     optionalDependencies:
       '@types/react': 19.2.2
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
 
   '@radix-ui/rect@1.1.1': {}
 
@@ -9205,6 +10044,69 @@ snapshots:
 
   quick-format-unescaped@4.0.4: {}
 
+  radix-ui@1.4.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-accessible-icon': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-alert-dialog': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-aspect-ratio': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-avatar': 1.1.10(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-checkbox': 1.3.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-context-menu': 2.2.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-form': 0.1.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-hover-card': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-label': 2.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-menubar': 1.1.16(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-navigation-menu': 1.2.14(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-one-time-password-field': 0.1.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-password-toggle-field': 0.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-progress': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-radio-group': 1.3.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-scroll-area': 1.2.10(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-select': 2.2.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator': 1.1.7(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slider': 1.3.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-switch': 1.2.6(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toast': 1.2.15(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.2)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.1(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.1(@types/react@19.2.2)
+
   rc@1.2.8:
     dependencies:
       deep-extend: 0.6.0
@@ -10022,6 +10924,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
 
+  use-sync-external-store@1.6.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   util-deprecate@1.0.2: {}
 
   v8-compile-cache-lib@3.0.1: {}
@@ -10215,7 +11121,8 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.11(@types/react@19.2.2)(react@19.1.0):
+  zustand@5.0.11(@types/react@19.2.2)(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)):
     optionalDependencies:
       '@types/react': 19.2.2
       react: 19.1.0
+      use-sync-external-store: 1.6.0(react@19.1.0)

--- a/src/app/(site)/interview/interview-page-client.tsx
+++ b/src/app/(site)/interview/interview-page-client.tsx
@@ -81,7 +81,11 @@ export function InterviewPageClient({
   }
 
   function shuffleQuestions() {
-    const shuffled = [...filteredQuestions].sort(() => Math.random() - 0.5);
+    const shuffled = [...filteredQuestions];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
     setFilteredQuestions(shuffled);
     setCurrentIndex(0);
   }

--- a/src/app/(site)/interview/interview-page-client.tsx
+++ b/src/app/(site)/interview/interview-page-client.tsx
@@ -1,0 +1,337 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Filter,
+  Lightbulb,
+  MessageCircle,
+  Shuffle,
+} from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+
+import type { InterviewQuestion } from '@/modules/interview/data/mappers';
+
+interface InterviewPageClientProps {
+  initialQuestions: InterviewQuestion[];
+  roles: string[];
+  categories: string[];
+}
+
+const DIFFICULTY_COLORS: Record<string, string> = {
+  easy: 'bg-green-100 text-green-700',
+  medium: 'bg-yellow-100 text-yellow-700',
+  hard: 'bg-red-100 text-red-700',
+};
+
+export function InterviewPageClient({
+  initialQuestions,
+  roles,
+  categories,
+}: InterviewPageClientProps) {
+  const [questions] = useState<InterviewQuestion[]>(initialQuestions);
+  const [filteredQuestions, setFilteredQuestions] =
+    useState<InterviewQuestion[]>(initialQuestions);
+  const [roleFilter, setRoleFilter] = useState<string>('all');
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+  const [difficultyFilter, setDifficultyFilter] = useState<string>('all');
+  const [practiceMode, setPracticeMode] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  function applyFilters(role: string, category: string, difficulty: string) {
+    let filtered = questions;
+    if (role !== 'all') filtered = filtered.filter((q) => q.role === role);
+    if (category !== 'all')
+      filtered = filtered.filter((q) => q.category === category);
+    if (difficulty !== 'all')
+      filtered = filtered.filter((q) => q.difficulty === difficulty);
+    setFilteredQuestions(filtered);
+    setCurrentIndex(0);
+  }
+
+  function handleRoleChange(value: string) {
+    setRoleFilter(value);
+    applyFilters(value, categoryFilter, difficultyFilter);
+  }
+
+  function handleCategoryChange(value: string) {
+    setCategoryFilter(value);
+    applyFilters(roleFilter, value, difficultyFilter);
+  }
+
+  function handleDifficultyChange(value: string) {
+    setDifficultyFilter(value);
+    applyFilters(roleFilter, categoryFilter, value);
+  }
+
+  function shuffleQuestions() {
+    const shuffled = [...filteredQuestions].sort(() => Math.random() - 0.5);
+    setFilteredQuestions(shuffled);
+    setCurrentIndex(0);
+  }
+
+  return (
+    <main className='container mx-auto py-8 px-4'>
+      <div className='flex items-center justify-between mb-8'>
+        <div>
+          <h1 className='text-3xl font-bold'>Interview Prep</h1>
+          <p className='text-muted-foreground mt-1'>
+            Practice common interview questions for your target role
+          </p>
+        </div>
+        <div className='flex items-center gap-2'>
+          <Button
+            variant={practiceMode ? 'default' : 'outline'}
+            onClick={() => {
+              setPracticeMode(!practiceMode);
+              setCurrentIndex(0);
+            }}
+          >
+            <MessageCircle className='h-4 w-4 mr-2' />
+            {practiceMode ? 'Exit Practice' : 'Practice Mode'}
+          </Button>
+          <Button variant='outline' onClick={shuffleQuestions}>
+            <Shuffle className='h-4 w-4 mr-2' />
+            Shuffle
+          </Button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className='flex flex-wrap gap-3 mb-6'>
+        <div className='flex items-center gap-2'>
+          <Filter className='h-4 w-4 text-muted-foreground' />
+          <Select value={roleFilter} onValueChange={handleRoleChange}>
+            <SelectTrigger className='w-[180px]'>
+              <SelectValue placeholder='Role' />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='all'>All Roles</SelectItem>
+              {roles.map((role) => (
+                <SelectItem key={role} value={role}>
+                  {role}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Select value={categoryFilter} onValueChange={handleCategoryChange}>
+          <SelectTrigger className='w-[180px]'>
+            <SelectValue placeholder='Category' />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='all'>All Categories</SelectItem>
+            {categories.map((cat) => (
+              <SelectItem key={cat} value={cat}>
+                {cat}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Select value={difficultyFilter} onValueChange={handleDifficultyChange}>
+          <SelectTrigger className='w-[150px]'>
+            <SelectValue placeholder='Difficulty' />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='all'>All Levels</SelectItem>
+            <SelectItem value='easy'>Easy</SelectItem>
+            <SelectItem value='medium'>Medium</SelectItem>
+            <SelectItem value='hard'>Hard</SelectItem>
+          </SelectContent>
+        </Select>
+        <Badge variant='secondary' className='self-center'>
+          {filteredQuestions.length} questions
+        </Badge>
+      </div>
+
+      {/* Practice Mode */}
+      {practiceMode && filteredQuestions.length > 0 ? (
+        <PracticeCard
+          question={filteredQuestions[currentIndex]}
+          index={currentIndex}
+          total={filteredQuestions.length}
+          onNext={() =>
+            setCurrentIndex((i) =>
+              Math.min(i + 1, filteredQuestions.length - 1)
+            )
+          }
+          onPrev={() => setCurrentIndex((i) => Math.max(i - 1, 0))}
+        />
+      ) : (
+        <div className='space-y-3'>
+          {filteredQuestions.length === 0 ? (
+            <Card>
+              <CardContent className='py-12 text-center text-muted-foreground'>
+                No questions match your filters. Try adjusting them.
+              </CardContent>
+            </Card>
+          ) : (
+            filteredQuestions.map((q) => (
+              <QuestionCard key={q.id} question={q} />
+            ))
+          )}
+        </div>
+      )}
+    </main>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+function QuestionCard({ question }: { question: InterviewQuestion }) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <Card>
+      <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+        <CollapsibleTrigger asChild>
+          <CardHeader className='cursor-pointer hover:bg-muted/50 transition-colors'>
+            <div className='flex items-start justify-between gap-4'>
+              <div className='space-y-1'>
+                <CardTitle className='text-base leading-snug'>
+                  {question.question}
+                </CardTitle>
+                <div className='flex items-center gap-2'>
+                  <Badge variant='outline' className='text-xs'>
+                    {question.role}
+                  </Badge>
+                  <Badge variant='secondary' className='text-xs'>
+                    {question.category}
+                  </Badge>
+                  <Badge
+                    className={`text-xs ${DIFFICULTY_COLORS[question.difficulty]}`}
+                    variant='secondary'
+                  >
+                    {question.difficulty}
+                  </Badge>
+                </div>
+              </div>
+              {isOpen ? (
+                <ChevronUp className='h-4 w-4 shrink-0' />
+              ) : (
+                <ChevronDown className='h-4 w-4 shrink-0' />
+              )}
+            </div>
+          </CardHeader>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <CardContent className='pt-0 space-y-3'>
+            {question.sampleAnswer && (
+              <div className='rounded-lg bg-muted p-3'>
+                <p className='text-sm font-medium mb-1'>Sample Answer</p>
+                <p className='text-sm text-muted-foreground'>
+                  {question.sampleAnswer}
+                </p>
+              </div>
+            )}
+            {question.tips && (
+              <div className='flex items-start gap-2 text-sm'>
+                <Lightbulb className='h-4 w-4 text-yellow-500 mt-0.5 shrink-0' />
+                <p className='text-muted-foreground'>{question.tips}</p>
+              </div>
+            )}
+          </CardContent>
+        </CollapsibleContent>
+      </Collapsible>
+    </Card>
+  );
+}
+
+interface PracticeCardProps {
+  question: InterviewQuestion;
+  index: number;
+  total: number;
+  onNext: () => void;
+  onPrev: () => void;
+}
+
+function PracticeCard({
+  question,
+  index,
+  total,
+  onNext,
+  onPrev,
+}: PracticeCardProps) {
+  const [showAnswer, setShowAnswer] = useState(false);
+
+  return (
+    <Card className='max-w-2xl mx-auto'>
+      <CardHeader>
+        <div className='flex items-center justify-between mb-2'>
+          <span className='text-sm text-muted-foreground'>
+            Question {index + 1} of {total}
+          </span>
+          <div className='flex items-center gap-2'>
+            <Badge variant='outline' className='text-xs'>
+              {question.role}
+            </Badge>
+            <Badge
+              className={`text-xs ${DIFFICULTY_COLORS[question.difficulty]}`}
+              variant='secondary'
+            >
+              {question.difficulty}
+            </Badge>
+          </div>
+        </div>
+        <CardTitle className='text-lg'>{question.question}</CardTitle>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        {showAnswer ? (
+          <div className='space-y-3'>
+            {question.sampleAnswer && (
+              <div className='rounded-lg bg-muted p-4'>
+                <p className='text-sm font-medium mb-1'>Sample Answer</p>
+                <p className='text-sm'>{question.sampleAnswer}</p>
+              </div>
+            )}
+            {question.tips && (
+              <div className='flex items-start gap-2 text-sm'>
+                <Lightbulb className='h-4 w-4 text-yellow-500 mt-0.5 shrink-0' />
+                <p>{question.tips}</p>
+              </div>
+            )}
+          </div>
+        ) : (
+          <Button
+            variant='outline'
+            className='w-full'
+            onClick={() => setShowAnswer(true)}
+          >
+            Show Answer
+          </Button>
+        )}
+
+        <div className='flex items-center justify-between pt-2'>
+          <Button variant='outline' onClick={onPrev} disabled={index === 0}>
+            Previous
+          </Button>
+          <Button
+            onClick={() => {
+              setShowAnswer(false);
+              onNext();
+            }}
+            disabled={index === total - 1}
+          >
+            Next
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(site)/interview/page.tsx
+++ b/src/app/(site)/interview/page.tsx
@@ -9,7 +9,7 @@ export const dynamic = 'force-dynamic';
 
 export default async function InterviewPage() {
   const [questions, roles, categories] = await Promise.all([
-    getInterviewQuestions({ limit: 20 }),
+    getInterviewQuestions({ limit: 100 }),
     getInterviewRoles(),
     getInterviewCategories(),
   ]);

--- a/src/app/(site)/interview/page.tsx
+++ b/src/app/(site)/interview/page.tsx
@@ -1,0 +1,24 @@
+import {
+  getInterviewQuestions,
+  getInterviewRoles,
+  getInterviewCategories,
+} from '@/modules/interview/data/queries';
+import { InterviewPageClient } from './interview-page-client';
+
+export const dynamic = 'force-dynamic';
+
+export default async function InterviewPage() {
+  const [questions, roles, categories] = await Promise.all([
+    getInterviewQuestions({ limit: 20 }),
+    getInterviewRoles(),
+    getInterviewCategories(),
+  ]);
+
+  return (
+    <InterviewPageClient
+      initialQuestions={questions}
+      roles={roles}
+      categories={categories}
+    />
+  );
+}

--- a/src/app/(site)/jobs/jobs-page-client.tsx
+++ b/src/app/(site)/jobs/jobs-page-client.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useTransition } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Plus,
   Briefcase,
@@ -37,12 +39,16 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 import type { Job, JobStats } from '@/modules/jobs/data/mappers';
-import type { JobStatusContract } from '@/modules/jobs/data/contracts';
+import { REVERSE_STATUS_MAP } from '@/modules/jobs/data/mappers';
 import {
   createJobAction,
   deleteJobAction,
   updateJobStatusAction,
 } from '@/modules/jobs/data/actions';
+import {
+  createJobSchema,
+  type CreateJobFormData,
+} from '@/lib/validations/jobs';
 
 interface JobsPageClientProps {
   initialJobs: Job[];
@@ -98,25 +104,31 @@ export function JobsPageClient({
   const [dialogOpen, setDialogOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('board');
 
-  function handleAddJob(formData: FormData) {
-    const title = formData.get('title') as string;
-    const company = formData.get('company') as string;
-    const url = (formData.get('url') as string) || undefined;
-    const location = (formData.get('location') as string) || undefined;
-    const status = (formData.get('status') as JobStatusContract) || 'SAVED';
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    reset: resetForm,
+    formState: { errors },
+  } = useForm<CreateJobFormData>({
+    resolver: zodResolver(createJobSchema),
+    defaultValues: { status: 'SAVED' },
+  });
 
+  function onSubmit(data: CreateJobFormData) {
     startTransition(async () => {
       const result = await createJobAction({
-        title,
-        company,
-        url,
-        location,
-        status,
+        title: data.title,
+        company: data.company,
+        url: data.url || undefined,
+        location: data.location || undefined,
+        status: data.status,
       });
       if (result.ok && result.data) {
         setJobs((prev) => [result.data!, ...prev]);
         setStats((prev) => ({ ...prev, total: prev.total + 1 }));
         setDialogOpen(false);
+        resetForm();
         toast.success(result.message);
       } else if (!result.ok) {
         toast.error(result.message);
@@ -125,17 +137,14 @@ export function JobsPageClient({
   }
 
   function handleStatusChange(jobId: string, newStatus: string) {
-    const statusMap: Record<string, JobStatusContract> = {
-      saved: 'SAVED',
-      applied: 'APPLIED',
-      interview: 'INTERVIEW',
-      offer: 'OFFER',
-      rejected: 'REJECTED',
-    };
+    const contractStatus =
+      REVERSE_STATUS_MAP[newStatus as keyof typeof REVERSE_STATUS_MAP];
+
+    if (!contractStatus) return;
 
     startTransition(async () => {
       const result = await updateJobStatusAction(jobId, {
-        status: statusMap[newStatus],
+        status: contractStatus,
       });
       if (result.ok && result.data) {
         setJobs((prev) => prev.map((j) => (j.id === jobId ? result.data! : j)));
@@ -179,45 +188,66 @@ export function JobsPageClient({
             <DialogHeader>
               <DialogTitle>Add Job Application</DialogTitle>
             </DialogHeader>
-            <form action={handleAddJob} className='space-y-4'>
+            <form onSubmit={handleSubmit(onSubmit)} className='space-y-4'>
               <div className='space-y-2'>
                 <Label htmlFor='title'>Job Title</Label>
                 <Input
                   id='title'
-                  name='title'
-                  required
                   placeholder='Software Engineer'
+                  aria-invalid={!!errors.title}
+                  {...register('title')}
                 />
+                {errors.title && (
+                  <p role='alert' className='text-xs text-feedback-error'>
+                    {errors.title.message}
+                  </p>
+                )}
               </div>
               <div className='space-y-2'>
                 <Label htmlFor='company'>Company</Label>
                 <Input
                   id='company'
-                  name='company'
-                  required
                   placeholder='Company name'
+                  aria-invalid={!!errors.company}
+                  {...register('company')}
                 />
+                {errors.company && (
+                  <p role='alert' className='text-xs text-feedback-error'>
+                    {errors.company.message}
+                  </p>
+                )}
               </div>
               <div className='space-y-2'>
                 <Label htmlFor='url'>Job URL</Label>
                 <Input
                   id='url'
-                  name='url'
                   type='url'
                   placeholder='https://...'
+                  aria-invalid={!!errors.url}
+                  {...register('url')}
                 />
+                {errors.url && (
+                  <p role='alert' className='text-xs text-feedback-error'>
+                    {errors.url.message}
+                  </p>
+                )}
               </div>
               <div className='space-y-2'>
                 <Label htmlFor='location'>Location</Label>
                 <Input
                   id='location'
-                  name='location'
                   placeholder='City, Country'
+                  {...register('location')}
                 />
               </div>
               <div className='space-y-2'>
                 <Label htmlFor='status'>Status</Label>
-                <Select name='status' defaultValue='SAVED'>
+                <Select
+                  defaultValue='SAVED'
+                  onValueChange={(v) =>
+                    setValue('status', v as CreateJobFormData['status'])
+                  }
+                >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>

--- a/src/app/(site)/jobs/jobs-page-client.tsx
+++ b/src/app/(site)/jobs/jobs-page-client.tsx
@@ -1,0 +1,487 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import {
+  Plus,
+  Briefcase,
+  Clock,
+  CheckCircle,
+  XCircle,
+  MessageSquare,
+  BarChart3,
+  Trash2,
+  ExternalLink,
+  MapPin,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+import type { Job, JobStats } from '@/modules/jobs/data/mappers';
+import type { JobStatusContract } from '@/modules/jobs/data/contracts';
+import {
+  createJobAction,
+  deleteJobAction,
+  updateJobStatusAction,
+} from '@/modules/jobs/data/actions';
+
+interface JobsPageClientProps {
+  initialJobs: Job[];
+  initialStats: JobStats;
+}
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; color: string; icon: React.ReactNode }
+> = {
+  saved: {
+    label: 'Saved',
+    color: 'bg-gray-100 text-gray-700',
+    icon: <Briefcase className='h-3 w-3' />,
+  },
+  applied: {
+    label: 'Applied',
+    color: 'bg-blue-100 text-blue-700',
+    icon: <Clock className='h-3 w-3' />,
+  },
+  interview: {
+    label: 'Interview',
+    color: 'bg-yellow-100 text-yellow-700',
+    icon: <MessageSquare className='h-3 w-3' />,
+  },
+  offer: {
+    label: 'Offer',
+    color: 'bg-green-100 text-green-700',
+    icon: <CheckCircle className='h-3 w-3' />,
+  },
+  rejected: {
+    label: 'Rejected',
+    color: 'bg-red-100 text-red-700',
+    icon: <XCircle className='h-3 w-3' />,
+  },
+};
+
+const STATUS_COLUMNS = [
+  'saved',
+  'applied',
+  'interview',
+  'offer',
+  'rejected',
+] as const;
+
+export function JobsPageClient({
+  initialJobs,
+  initialStats,
+}: JobsPageClientProps) {
+  const [jobs, setJobs] = useState<Job[]>(initialJobs);
+  const [stats, setStats] = useState<JobStats>(initialStats);
+  const [isPending, startTransition] = useTransition();
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('board');
+
+  function handleAddJob(formData: FormData) {
+    const title = formData.get('title') as string;
+    const company = formData.get('company') as string;
+    const url = (formData.get('url') as string) || undefined;
+    const location = (formData.get('location') as string) || undefined;
+    const status = (formData.get('status') as JobStatusContract) || 'SAVED';
+
+    startTransition(async () => {
+      const result = await createJobAction({
+        title,
+        company,
+        url,
+        location,
+        status,
+      });
+      if (result.ok && result.data) {
+        setJobs((prev) => [result.data!, ...prev]);
+        setStats((prev) => ({ ...prev, total: prev.total + 1 }));
+        setDialogOpen(false);
+        toast.success(result.message);
+      } else if (!result.ok) {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  function handleStatusChange(jobId: string, newStatus: string) {
+    const statusMap: Record<string, JobStatusContract> = {
+      saved: 'SAVED',
+      applied: 'APPLIED',
+      interview: 'INTERVIEW',
+      offer: 'OFFER',
+      rejected: 'REJECTED',
+    };
+
+    startTransition(async () => {
+      const result = await updateJobStatusAction(jobId, {
+        status: statusMap[newStatus],
+      });
+      if (result.ok && result.data) {
+        setJobs((prev) => prev.map((j) => (j.id === jobId ? result.data! : j)));
+        toast.success(result.message);
+      } else if (!result.ok) {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  function handleDelete(jobId: string) {
+    startTransition(async () => {
+      const result = await deleteJobAction(jobId);
+      if (result.ok) {
+        setJobs((prev) => prev.filter((j) => j.id !== jobId));
+        setStats((prev) => ({ ...prev, total: prev.total - 1 }));
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  return (
+    <main className='container mx-auto py-8 px-4'>
+      <div className='flex items-center justify-between mb-8'>
+        <div>
+          <h1 className='text-3xl font-bold'>Job Tracker</h1>
+          <p className='text-muted-foreground mt-1'>
+            Track your job applications in one place
+          </p>
+        </div>
+        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className='h-4 w-4 mr-2' />
+              Add Job
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Add Job Application</DialogTitle>
+            </DialogHeader>
+            <form action={handleAddJob} className='space-y-4'>
+              <div className='space-y-2'>
+                <Label htmlFor='title'>Job Title</Label>
+                <Input
+                  id='title'
+                  name='title'
+                  required
+                  placeholder='Software Engineer'
+                />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='company'>Company</Label>
+                <Input
+                  id='company'
+                  name='company'
+                  required
+                  placeholder='Company name'
+                />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='url'>Job URL</Label>
+                <Input
+                  id='url'
+                  name='url'
+                  type='url'
+                  placeholder='https://...'
+                />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='location'>Location</Label>
+                <Input
+                  id='location'
+                  name='location'
+                  placeholder='City, Country'
+                />
+              </div>
+              <div className='space-y-2'>
+                <Label htmlFor='status'>Status</Label>
+                <Select name='status' defaultValue='SAVED'>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value='SAVED'>Saved</SelectItem>
+                    <SelectItem value='APPLIED'>Applied</SelectItem>
+                    <SelectItem value='INTERVIEW'>Interview</SelectItem>
+                    <SelectItem value='OFFER'>Offer</SelectItem>
+                    <SelectItem value='REJECTED'>Rejected</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <Button type='submit' className='w-full' disabled={isPending}>
+                {isPending ? 'Adding...' : 'Add Job'}
+              </Button>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Stats cards */}
+      <div className='grid grid-cols-2 md:grid-cols-4 gap-4 mb-8'>
+        <Card>
+          <CardContent className='pt-6'>
+            <div className='flex items-center gap-2'>
+              <BarChart3 className='h-4 w-4 text-muted-foreground' />
+              <span className='text-sm text-muted-foreground'>Total</span>
+            </div>
+            <p className='text-2xl font-bold mt-1'>{stats.total}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className='pt-6'>
+            <div className='flex items-center gap-2'>
+              <Clock className='h-4 w-4 text-blue-500' />
+              <span className='text-sm text-muted-foreground'>
+                Applied This Week
+              </span>
+            </div>
+            <p className='text-2xl font-bold mt-1'>{stats.appliedThisWeek}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className='pt-6'>
+            <div className='flex items-center gap-2'>
+              <MessageSquare className='h-4 w-4 text-yellow-500' />
+              <span className='text-sm text-muted-foreground'>Interviews</span>
+            </div>
+            <p className='text-2xl font-bold mt-1'>{stats.pendingInterviews}</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className='pt-6'>
+            <div className='flex items-center gap-2'>
+              <CheckCircle className='h-4 w-4 text-green-500' />
+              <span className='text-sm text-muted-foreground'>Offers</span>
+            </div>
+            <p className='text-2xl font-bold mt-1'>{stats.activeOffers}</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <TabsList className='mb-4'>
+          <TabsTrigger value='board'>Board View</TabsTrigger>
+          <TabsTrigger value='list'>List View</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value='board'>
+          <div className='grid grid-cols-1 md:grid-cols-5 gap-4'>
+            {STATUS_COLUMNS.map((status) => {
+              const config = STATUS_CONFIG[status];
+              const columnJobs = jobs.filter((j) => j.status === status);
+
+              return (
+                <div key={status} className='space-y-3'>
+                  <div className='flex items-center gap-2 px-2'>
+                    {config.icon}
+                    <span className='font-medium text-sm'>{config.label}</span>
+                    <Badge variant='secondary' className='ml-auto'>
+                      {columnJobs.length}
+                    </Badge>
+                  </div>
+                  <div className='space-y-2 min-h-[200px]'>
+                    {columnJobs.map((job) => (
+                      <JobCard
+                        key={job.id}
+                        job={job}
+                        onStatusChange={handleStatusChange}
+                        onDelete={handleDelete}
+                        isPending={isPending}
+                      />
+                    ))}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </TabsContent>
+
+        <TabsContent value='list'>
+          <div className='space-y-2'>
+            {jobs.length === 0 ? (
+              <Card>
+                <CardContent className='py-12 text-center text-muted-foreground'>
+                  No jobs tracked yet. Add your first job application!
+                </CardContent>
+              </Card>
+            ) : (
+              jobs.map((job) => (
+                <JobListItem
+                  key={job.id}
+                  job={job}
+                  onStatusChange={handleStatusChange}
+                  onDelete={handleDelete}
+                  isPending={isPending}
+                />
+              ))
+            )}
+          </div>
+        </TabsContent>
+      </Tabs>
+    </main>
+  );
+}
+
+// ─── Sub-components ─────────────────────────────────────────────────────────
+
+interface JobCardProps {
+  job: Job;
+  onStatusChange: (id: string, status: string) => void;
+  onDelete: (id: string) => void;
+  isPending: boolean;
+}
+
+function JobCard({ job, onStatusChange, onDelete, isPending }: JobCardProps) {
+  return (
+    <Card className='cursor-pointer hover:shadow-md transition-shadow'>
+      <CardContent className='p-3 space-y-2'>
+        <div className='flex items-start justify-between'>
+          <div className='min-w-0'>
+            <h3 className='font-medium text-sm truncate'>{job.title}</h3>
+            <p className='text-xs text-muted-foreground truncate'>
+              {job.company}
+            </p>
+          </div>
+          <Button
+            variant='ghost'
+            size='icon'
+            className='h-6 w-6 shrink-0'
+            onClick={() => onDelete(job.id)}
+            disabled={isPending}
+          >
+            <Trash2 className='h-3 w-3' />
+          </Button>
+        </div>
+        {job.location && (
+          <div className='flex items-center gap-1 text-xs text-muted-foreground'>
+            <MapPin className='h-3 w-3' />
+            <span className='truncate'>{job.location}</span>
+          </div>
+        )}
+        {job.url && (
+          <a
+            href={job.url}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='flex items-center gap-1 text-xs text-blue-600 hover:underline'
+          >
+            <ExternalLink className='h-3 w-3' />
+            View listing
+          </a>
+        )}
+        <Select
+          value={job.status}
+          onValueChange={(v) => onStatusChange(job.id, v)}
+          disabled={isPending}
+        >
+          <SelectTrigger className='h-7 text-xs'>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value='saved'>Saved</SelectItem>
+            <SelectItem value='applied'>Applied</SelectItem>
+            <SelectItem value='interview'>Interview</SelectItem>
+            <SelectItem value='offer'>Offer</SelectItem>
+            <SelectItem value='rejected'>Rejected</SelectItem>
+          </SelectContent>
+        </Select>
+      </CardContent>
+    </Card>
+  );
+}
+
+interface JobListItemProps {
+  job: Job;
+  onStatusChange: (id: string, status: string) => void;
+  onDelete: (id: string) => void;
+  isPending: boolean;
+}
+
+function JobListItem({
+  job,
+  onStatusChange,
+  onDelete,
+  isPending,
+}: JobListItemProps) {
+  const config = STATUS_CONFIG[job.status];
+
+  return (
+    <Card>
+      <CardContent className='flex items-center gap-4 py-3 px-4'>
+        <div className='flex-1 min-w-0'>
+          <div className='flex items-center gap-2'>
+            <h3 className='font-medium truncate'>{job.title}</h3>
+            <Badge className={config.color} variant='secondary'>
+              {config.label}
+            </Badge>
+          </div>
+          <div className='flex items-center gap-3 text-sm text-muted-foreground mt-0.5'>
+            <span>{job.company}</span>
+            {job.location && (
+              <span className='flex items-center gap-1'>
+                <MapPin className='h-3 w-3' />
+                {job.location}
+              </span>
+            )}
+            {job.isRemote && <Badge variant='outline'>Remote</Badge>}
+          </div>
+        </div>
+        <div className='flex items-center gap-2 shrink-0'>
+          {job.url && (
+            <Button variant='ghost' size='icon' asChild>
+              <a href={job.url} target='_blank' rel='noopener noreferrer'>
+                <ExternalLink className='h-4 w-4' />
+              </a>
+            </Button>
+          )}
+          <Select
+            value={job.status}
+            onValueChange={(v) => onStatusChange(job.id, v)}
+            disabled={isPending}
+          >
+            <SelectTrigger className='w-[130px]'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='saved'>Saved</SelectItem>
+              <SelectItem value='applied'>Applied</SelectItem>
+              <SelectItem value='interview'>Interview</SelectItem>
+              <SelectItem value='offer'>Offer</SelectItem>
+              <SelectItem value='rejected'>Rejected</SelectItem>
+            </SelectContent>
+          </Select>
+          <Button
+            variant='ghost'
+            size='icon'
+            onClick={() => onDelete(job.id)}
+            disabled={isPending}
+          >
+            <Trash2 className='h-4 w-4' />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(site)/jobs/page.tsx
+++ b/src/app/(site)/jobs/page.tsx
@@ -1,0 +1,10 @@
+import { getJobs } from '@/modules/jobs/data/queries';
+import { getJobStats } from '@/modules/jobs/data/queries';
+import { JobsPageClient } from './jobs-page-client';
+
+export const dynamic = 'force-dynamic';
+
+export default async function JobsPage() {
+  const [jobs, stats] = await Promise.all([getJobs(), getJobStats()]);
+  return <JobsPageClient initialJobs={jobs} initialStats={stats} />;
+}

--- a/src/app/(site)/jobs/page.tsx
+++ b/src/app/(site)/jobs/page.tsx
@@ -1,5 +1,4 @@
-import { getJobs } from '@/modules/jobs/data/queries';
-import { getJobStats } from '@/modules/jobs/data/queries';
+import { getJobs, getJobStats } from '@/modules/jobs/data/queries';
 import { JobsPageClient } from './jobs-page-client';
 
 export const dynamic = 'force-dynamic';

--- a/src/app/(site)/skills/page.tsx
+++ b/src/app/(site)/skills/page.tsx
@@ -1,0 +1,16 @@
+import {
+  getSkillCategories,
+  getSkillRoles,
+} from '@/modules/skills/data/queries';
+import { SkillsPageClient } from './skills-page-client';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SkillsPage() {
+  const [categories, roles] = await Promise.all([
+    getSkillCategories(),
+    getSkillRoles(),
+  ]);
+
+  return <SkillsPageClient categories={categories} roles={roles} />;
+}

--- a/src/app/(site)/skills/skills-page-client.tsx
+++ b/src/app/(site)/skills/skills-page-client.tsx
@@ -99,7 +99,7 @@ export function SkillsPageClient({ categories, roles }: SkillsPageClientProps) {
 
       {/* Categories overview */}
       <div className='grid grid-cols-2 md:grid-cols-5 gap-3 mb-8'>
-        {categories.slice(0, 10).map((cat) => (
+        {categories.map((cat) => (
           <Card key={cat.id}>
             <CardContent className='pt-4 pb-3 px-4'>
               <p className='font-medium text-sm'>{cat.name}</p>

--- a/src/app/(site)/skills/skills-page-client.tsx
+++ b/src/app/(site)/skills/skills-page-client.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { BarChart3, BookOpen, Target, TrendingUp } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Slider } from '@/components/ui/slider';
+
+import type {
+  SkillAssessment,
+  SkillCategory,
+} from '@/modules/skills/data/mappers';
+import { assessSkillsAction } from '@/modules/skills/data/actions';
+
+interface SkillsPageClientProps {
+  categories: SkillCategory[];
+  roles: string[];
+}
+
+interface SkillInput {
+  name: string;
+  level: number;
+}
+
+export function SkillsPageClient({ categories, roles }: SkillsPageClientProps) {
+  const [isPending, startTransition] = useTransition();
+  const [selectedRole, setSelectedRole] = useState<string>('');
+  const [skillInputs, setSkillInputs] = useState<SkillInput[]>([
+    { name: '', level: 50 },
+  ]);
+  const [assessment, setAssessment] = useState<SkillAssessment | null>(null);
+
+  function addSkillInput() {
+    setSkillInputs((prev) => [...prev, { name: '', level: 50 }]);
+  }
+
+  function updateSkillInput(
+    index: number,
+    field: 'name' | 'level',
+    value: string | number
+  ) {
+    setSkillInputs((prev) =>
+      prev.map((s, i) => (i === index ? { ...s, [field]: value } : s))
+    );
+  }
+
+  function removeSkillInput(index: number) {
+    setSkillInputs((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function handleAssess() {
+    if (!selectedRole) {
+      toast.error('Please select a target role.');
+      return;
+    }
+
+    const validSkills = skillInputs.filter((s) => s.name.trim());
+    if (validSkills.length === 0) {
+      toast.error('Please add at least one skill.');
+      return;
+    }
+
+    startTransition(async () => {
+      const result = await assessSkillsAction({
+        role: selectedRole,
+        skills: validSkills,
+      });
+      if (result.ok && result.data) {
+        setAssessment(result.data);
+      } else if (!result.ok) {
+        toast.error(result.message);
+      }
+    });
+  }
+
+  return (
+    <main className='container mx-auto py-8 px-4'>
+      <div className='mb-8'>
+        <h1 className='text-3xl font-bold'>Skills Analysis</h1>
+        <p className='text-muted-foreground mt-1'>
+          Assess your skills and discover career growth paths
+        </p>
+      </div>
+
+      {/* Categories overview */}
+      <div className='grid grid-cols-2 md:grid-cols-5 gap-3 mb-8'>
+        {categories.slice(0, 10).map((cat) => (
+          <Card key={cat.id}>
+            <CardContent className='pt-4 pb-3 px-4'>
+              <p className='font-medium text-sm'>{cat.name}</p>
+              {cat.description && (
+                <p className='text-xs text-muted-foreground mt-0.5'>
+                  {cat.description}
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className='grid grid-cols-1 lg:grid-cols-2 gap-8'>
+        {/* Assessment form */}
+        <Card>
+          <CardHeader>
+            <CardTitle className='flex items-center gap-2'>
+              <Target className='h-5 w-5' />
+              Skill Assessment
+            </CardTitle>
+          </CardHeader>
+          <CardContent className='space-y-4'>
+            <div className='space-y-2'>
+              <Label>Target Role</Label>
+              <Select value={selectedRole} onValueChange={setSelectedRole}>
+                <SelectTrigger>
+                  <SelectValue placeholder='Select a role' />
+                </SelectTrigger>
+                <SelectContent>
+                  {roles.map((role) => (
+                    <SelectItem key={role} value={role}>
+                      {role}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className='space-y-3'>
+              <Label>Your Skills</Label>
+              {skillInputs.map((skill, index) => (
+                <div key={index} className='flex items-center gap-2'>
+                  <Input
+                    placeholder='Skill name'
+                    value={skill.name}
+                    onChange={(e) =>
+                      updateSkillInput(index, 'name', e.target.value)
+                    }
+                    className='flex-1'
+                  />
+                  <div className='w-24 flex items-center gap-1'>
+                    <Slider
+                      value={[skill.level]}
+                      onValueChange={([v]) =>
+                        updateSkillInput(index, 'level', v)
+                      }
+                      max={100}
+                      step={5}
+                    />
+                    <span className='text-xs w-8 text-right'>
+                      {skill.level}
+                    </span>
+                  </div>
+                  {skillInputs.length > 1 && (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      onClick={() => removeSkillInput(index)}
+                    >
+                      ×
+                    </Button>
+                  )}
+                </div>
+              ))}
+              <Button variant='outline' size='sm' onClick={addSkillInput}>
+                + Add Skill
+              </Button>
+            </div>
+
+            <Button
+              className='w-full'
+              onClick={handleAssess}
+              disabled={isPending}
+            >
+              {isPending ? 'Analyzing...' : 'Assess Skills'}
+            </Button>
+          </CardContent>
+        </Card>
+
+        {/* Assessment results */}
+        <div className='space-y-4'>
+          {assessment ? (
+            <>
+              <Card>
+                <CardHeader>
+                  <CardTitle className='flex items-center gap-2'>
+                    <BarChart3 className='h-5 w-5' />
+                    Readiness Score
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className='space-y-2'>
+                    <div className='flex items-center justify-between'>
+                      <span className='text-sm text-muted-foreground'>
+                        {assessment.role}
+                      </span>
+                      <span className='text-2xl font-bold'>
+                        {assessment.readinessScore}%
+                      </span>
+                    </div>
+                    <Progress value={assessment.readinessScore} />
+                  </div>
+                </CardContent>
+              </Card>
+
+              {assessment.gaps.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                      <TrendingUp className='h-5 w-5' />
+                      Skill Gaps
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className='space-y-3'>
+                    {assessment.gaps.map((gap) => (
+                      <div key={gap.skillName} className='space-y-1'>
+                        <div className='flex items-center justify-between'>
+                          <div className='flex items-center gap-2'>
+                            <span className='text-sm font-medium'>
+                              {gap.skillName}
+                            </span>
+                            <Badge variant='secondary' className='text-xs'>
+                              {gap.category}
+                            </Badge>
+                          </div>
+                          <span className='text-xs text-muted-foreground'>
+                            {gap.currentLevel}/{gap.requiredLevel}
+                          </span>
+                        </div>
+                        <Progress
+                          value={(gap.currentLevel / gap.requiredLevel) * 100}
+                          className='h-2'
+                        />
+                      </div>
+                    ))}
+                  </CardContent>
+                </Card>
+              )}
+            </>
+          ) : (
+            <Card>
+              <CardContent className='py-12 text-center text-muted-foreground'>
+                <BookOpen className='h-12 w-12 mx-auto mb-4 opacity-50' />
+                <p>
+                  Enter your skills and select a target role to see your
+                  assessment.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(site)/skills/skills-page-client.tsx
+++ b/src/app/(site)/skills/skills-page-client.tsx
@@ -20,7 +20,7 @@ import {
 import { Slider } from '@/components/ui/slider';
 
 import type {
-  SkillAssessment,
+  SkillGapResult,
   SkillCategory,
 } from '@/modules/skills/data/mappers';
 import { assessSkillsAction } from '@/modules/skills/data/actions';
@@ -41,7 +41,7 @@ export function SkillsPageClient({ categories, roles }: SkillsPageClientProps) {
   const [skillInputs, setSkillInputs] = useState<SkillInput[]>([
     { name: '', level: 50 },
   ]);
-  const [assessment, setAssessment] = useState<SkillAssessment | null>(null);
+  const [assessment, setAssessment] = useState<SkillGapResult | null>(null);
 
   function addSkillInput() {
     setSkillInputs((prev) => [...prev, { name: '', level: 50 }]);
@@ -67,7 +67,9 @@ export function SkillsPageClient({ categories, roles }: SkillsPageClientProps) {
       return;
     }
 
-    const validSkills = skillInputs.filter((s) => s.name.trim());
+    const validSkills = skillInputs
+      .filter((s) => s.name.trim())
+      .map((s) => s.name.trim());
     if (validSkills.length === 0) {
       toast.error('Please add at least one skill.');
       return;
@@ -75,8 +77,8 @@ export function SkillsPageClient({ categories, roles }: SkillsPageClientProps) {
 
     startTransition(async () => {
       const result = await assessSkillsAction({
-        role: selectedRole,
-        skills: validSkills,
+        targetRole: selectedRole,
+        currentSkills: validSkills,
       });
       if (result.ok && result.data) {
         setAssessment(result.data);
@@ -203,47 +205,57 @@ export function SkillsPageClient({ categories, roles }: SkillsPageClientProps) {
                   <div className='space-y-2'>
                     <div className='flex items-center justify-between'>
                       <span className='text-sm text-muted-foreground'>
-                        {assessment.role}
+                        {assessment.targetRole}
                       </span>
                       <span className='text-2xl font-bold'>
-                        {assessment.readinessScore}%
+                        {assessment.overallReadiness}%
                       </span>
                     </div>
-                    <Progress value={assessment.readinessScore} />
+                    <Progress value={assessment.overallReadiness} />
                   </div>
                 </CardContent>
               </Card>
+
+              {assessment.strengths.length > 0 && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className='flex items-center gap-2'>
+                      <TrendingUp className='h-5 w-5' />
+                      Strengths
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <div className='flex flex-wrap gap-2'>
+                      {assessment.strengths.map((strength) => (
+                        <Badge key={strength} variant='secondary'>
+                          {strength}
+                        </Badge>
+                      ))}
+                    </div>
+                  </CardContent>
+                </Card>
+              )}
 
               {assessment.gaps.length > 0 && (
                 <Card>
                   <CardHeader>
                     <CardTitle className='flex items-center gap-2'>
-                      <TrendingUp className='h-5 w-5' />
-                      Skill Gaps
+                      <BookOpen className='h-5 w-5' />
+                      Gaps to Fill
                     </CardTitle>
                   </CardHeader>
-                  <CardContent className='space-y-3'>
-                    {assessment.gaps.map((gap) => (
-                      <div key={gap.skillName} className='space-y-1'>
-                        <div className='flex items-center justify-between'>
-                          <div className='flex items-center gap-2'>
-                            <span className='text-sm font-medium'>
-                              {gap.skillName}
-                            </span>
-                            <Badge variant='secondary' className='text-xs'>
-                              {gap.category}
-                            </Badge>
-                          </div>
-                          <span className='text-xs text-muted-foreground'>
-                            {gap.currentLevel}/{gap.requiredLevel}
-                          </span>
-                        </div>
-                        <Progress
-                          value={(gap.currentLevel / gap.requiredLevel) * 100}
-                          className='h-2'
-                        />
-                      </div>
-                    ))}
+                  <CardContent>
+                    <div className='flex flex-wrap gap-2'>
+                      {assessment.gaps.map((gap) => (
+                        <Badge
+                          key={gap}
+                          variant='outline'
+                          className='text-feedback-error'
+                        >
+                          {gap}
+                        </Badge>
+                      ))}
+                    </div>
                   </CardContent>
                 </Card>
               )}

--- a/src/components/common/navbar-client.tsx
+++ b/src/components/common/navbar-client.tsx
@@ -35,7 +35,7 @@ interface NavbarClientProps {
   currentUser: NavbarUser | null;
 }
 
-const routeList: RouteProps[] = [
+const publicRouteList: RouteProps[] = [
   {
     href: '#templates',
     label: 'Templates',
@@ -50,12 +50,36 @@ const routeList: RouteProps[] = [
   },
 ];
 
+const authenticatedRouteList: RouteProps[] = [
+  {
+    href: '/dashboard',
+    label: 'Dashboard',
+  },
+  {
+    href: '/jobs',
+    label: 'Jobs',
+  },
+  {
+    href: '/skills',
+    label: 'Skills',
+  },
+  {
+    href: '/interview',
+    label: 'Interview',
+  },
+];
+
 export function NavbarClient({ currentUser }: NavbarClientProps) {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const pathname = usePathname();
   const isLandingPage = pathname === '/';
   const showAccountMenu = Boolean(currentUser && !isLandingPage);
   const showGetStarted = isLandingPage || !currentUser;
+  const routeList = isLandingPage
+    ? publicRouteList
+    : currentUser
+      ? authenticatedRouteList
+      : publicRouteList;
 
   return (
     <header className='sticky top-0 z-40 w-full bg-white shadow-(--shadow-sm)'>

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Collapsible as CollapsiblePrimitive } from 'radix-ui';
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot='collapsible' {...props} />;
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot='collapsible-trigger'
+      {...props}
+    />
+  );
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot='collapsible-content'
+      {...props}
+    />
+  );
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import * as React from 'react';
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot='dialog' {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot='dialog-trigger' {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot='dialog-portal' {...props} />;
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot='dialog-close' {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot='dialog-overlay'
+      className={cn(
+        'fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal data-slot='dialog-portal'>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot='dialog-content'
+        className={cn(
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot='dialog-close'
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className='sr-only'>Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='dialog-header'
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot='dialog-footer'
+      className={cn(
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant='outline'>Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot='dialog-title'
+      className={cn('text-lg leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot='dialog-description'
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+};

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import * as React from 'react';
+import { Label as LabelPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot='label'
+      className={cn(
+        'flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Label };

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as React from 'react';
+import { Progress as ProgressPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot='progress'
+      className={cn(
+        'relative h-2 w-full overflow-hidden rounded-full bg-primary/20',
+        className
+      )}
+      {...props}
+    >
+      <ProgressPrimitive.Indicator
+        data-slot='progress-indicator'
+        className='h-full w-full flex-1 bg-primary transition-all'
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import * as React from 'react';
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from 'lucide-react';
+import { Select as SelectPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Select({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+  return <SelectPrimitive.Root data-slot='select' {...props} />;
+}
+
+function SelectGroup({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Group>) {
+  return <SelectPrimitive.Group data-slot='select-group' {...props} />;
+}
+
+function SelectValue({
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Value>) {
+  return <SelectPrimitive.Value data-slot='select-value' {...props} />;
+}
+
+function SelectTrigger({
+  className,
+  size = 'default',
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
+  size?: 'sm' | 'default';
+}) {
+  return (
+    <SelectPrimitive.Trigger
+      data-slot='select-trigger'
+      data-size={size}
+      className={cn(
+        "flex w-fit items-center justify-between gap-2 rounded-md border border-input bg-transparent px-3 py-2 text-sm whitespace-nowrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[placeholder]:text-muted-foreground data-[size=default]:h-9 data-[size=sm]:h-8 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-2 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDownIcon className='size-4 opacity-50' />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+function SelectContent({
+  className,
+  children,
+  position = 'item-aligned',
+  align = 'center',
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Content>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        data-slot='select-content'
+        className={cn(
+          'relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border bg-popover text-popover-foreground shadow-md data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+          position === 'popper' &&
+            'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+          className
+        )}
+        position={position}
+        align={align}
+        {...props}
+      >
+        <SelectScrollUpButton />
+        <SelectPrimitive.Viewport
+          className={cn(
+            'p-1',
+            position === 'popper' &&
+              'h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)] scroll-my-1'
+          )}
+        >
+          {children}
+        </SelectPrimitive.Viewport>
+        <SelectScrollDownButton />
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+function SelectLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Label>) {
+  return (
+    <SelectPrimitive.Label
+      data-slot='select-label'
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Item>) {
+  return (
+    <SelectPrimitive.Item
+      data-slot='select-item'
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-sm py-1.5 pr-8 pl-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
+        className
+      )}
+      {...props}
+    >
+      <span
+        data-slot='select-item-indicator'
+        className='absolute right-2 flex size-3.5 items-center justify-center'
+      >
+        <SelectPrimitive.ItemIndicator>
+          <CheckIcon className='size-4' />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  );
+}
+
+function SelectSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.Separator>) {
+  return (
+    <SelectPrimitive.Separator
+      data-slot='select-separator'
+      className={cn('pointer-events-none -mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function SelectScrollUpButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollUpButton>) {
+  return (
+    <SelectPrimitive.ScrollUpButton
+      data-slot='select-scroll-up-button'
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className
+      )}
+      {...props}
+    >
+      <ChevronUpIcon className='size-4' />
+    </SelectPrimitive.ScrollUpButton>
+  );
+}
+
+function SelectScrollDownButton({
+  className,
+  ...props
+}: React.ComponentProps<typeof SelectPrimitive.ScrollDownButton>) {
+  return (
+    <SelectPrimitive.ScrollDownButton
+      data-slot='select-scroll-down-button'
+      className={cn(
+        'flex cursor-default items-center justify-center py-1',
+        className
+      )}
+      {...props}
+    >
+      <ChevronDownIcon className='size-4' />
+    </SelectPrimitive.ScrollDownButton>
+  );
+}
+
+export {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+};

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import * as React from 'react';
+import { Slider as SliderPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: React.ComponentProps<typeof SliderPrimitive.Root>) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  );
+
+  return (
+    <SliderPrimitive.Root
+      data-slot='slider'
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        'relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col',
+        className
+      )}
+      {...props}
+    >
+      <SliderPrimitive.Track
+        data-slot='slider-track'
+        className={cn(
+          'relative grow overflow-hidden rounded-full bg-muted data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5'
+        )}
+      >
+        <SliderPrimitive.Range
+          data-slot='slider-range'
+          className={cn(
+            'absolute bg-primary data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full'
+          )}
+        />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot='slider-thumb'
+          key={index}
+          className='block size-4 shrink-0 rounded-full border border-primary bg-white shadow-sm ring-ring/50 transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50'
+        />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider };

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { Tabs as TabsPrimitive } from 'radix-ui';
+
+import { cn } from '@/lib/utils';
+
+function Tabs({
+  className,
+  orientation = 'horizontal',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+  return (
+    <TabsPrimitive.Root
+      data-slot='tabs'
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        'group/tabs flex gap-2 data-[orientation=horizontal]:flex-col',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const tabsListVariants = cva(
+  'group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-[orientation=horizontal]/tabs:h-9 group-data-[orientation=vertical]/tabs:h-fit group-data-[orientation=vertical]/tabs:flex-col data-[variant=line]:rounded-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-muted',
+        line: 'gap-1 bg-transparent',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+function TabsList({
+  className,
+  variant = 'default',
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.List> &
+  VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot='tabs-list'
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot='tabs-trigger'
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-[orientation=vertical]/tabs:w-full group-data-[orientation=vertical]/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 group-data-[variant=default]/tabs-list:data-[state=active]:shadow-sm group-data-[variant=line]/tabs-list:data-[state=active]:shadow-none dark:text-muted-foreground dark:hover:text-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        'group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent',
+        'data-[state=active]:bg-background data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 dark:data-[state=active]:text-foreground',
+        'after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+  return (
+    <TabsPrimitive.Content
+      data-slot='tabs-content'
+      className={cn('flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants };

--- a/src/lib/validations/jobs.ts
+++ b/src/lib/validations/jobs.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+const jobStatusSchema = z.enum([
+  'SAVED',
+  'APPLIED',
+  'INTERVIEW',
+  'OFFER',
+  'REJECTED',
+]);
+
+export const createJobSchema = z.object({
+  title: z
+    .string()
+    .min(1, 'Job title is required')
+    .max(200, 'Job title must be 200 characters or fewer'),
+  company: z
+    .string()
+    .min(1, 'Company name is required')
+    .max(200, 'Company name must be 200 characters or fewer'),
+  url: z.string().url('Please enter a valid URL').optional().or(z.literal('')),
+  location: z.string().max(200).optional().or(z.literal('')),
+  status: jobStatusSchema,
+});
+
+export type CreateJobFormData = z.infer<typeof createJobSchema>;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,7 +2,15 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
 // Protected route prefixes
-const PROTECTED_PREFIXES = ['/onboarding', '/dashboard', '/cv', '/settings'];
+const PROTECTED_PREFIXES = [
+  '/onboarding',
+  '/dashboard',
+  '/cv',
+  '/settings',
+  '/jobs',
+  '/skills',
+  '/interview',
+];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/src/modules/ai/data/actions.ts
+++ b/src/modules/ai/data/actions.ts
@@ -1,0 +1,68 @@
+'use server';
+
+import { HttpError } from '@/shared/http/http-error';
+import type { OptimizeCvRequest } from './contracts';
+import { analyzeCv, optimizeCvForJob } from './mutations';
+import type { CvAnalysisResult, CvOptimizationResult } from './mappers';
+
+// ─── Action types ─────────────────────────────────────────────────────────────
+
+export type AiActionCode =
+  | 'not_found'
+  | 'forbidden'
+  | 'unauthorized'
+  | 'unknown';
+
+export interface ActionSuccessResult<T = undefined> {
+  ok: true;
+  data?: T;
+}
+
+export interface ActionFailureResult {
+  ok: false;
+  code: AiActionCode;
+  message: string;
+}
+
+export type ActionResult<T = undefined> =
+  | ActionSuccessResult<T>
+  | ActionFailureResult;
+
+function toFailureResult(
+  error: unknown,
+  fallbackMessage: string
+): ActionFailureResult {
+  if (error instanceof HttpError) {
+    const message = error.serverMessage ?? error.message ?? fallbackMessage;
+    if (error.isNotFound) return { ok: false, code: 'not_found', message };
+    if (error.isForbidden) return { ok: false, code: 'forbidden', message };
+    if (error.isUnauthorized)
+      return { ok: false, code: 'unauthorized', message };
+  }
+  return { ok: false, code: 'unknown', message: fallbackMessage };
+}
+
+// ─── AI actions ───────────────────────────────────────────────────────────────
+
+export async function analyzeCvAction(
+  cvId: string
+): Promise<ActionResult<CvAnalysisResult>> {
+  try {
+    const result = await analyzeCv(cvId);
+    return { ok: true, data: result };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to analyze your CV.');
+  }
+}
+
+export async function optimizeCvAction(
+  cvId: string,
+  input: OptimizeCvRequest
+): Promise<ActionResult<CvOptimizationResult>> {
+  try {
+    const result = await optimizeCvForJob(cvId, input);
+    return { ok: true, data: result };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to optimize your CV.');
+  }
+}

--- a/src/modules/ai/data/actions.ts
+++ b/src/modules/ai/data/actions.ts
@@ -1,46 +1,9 @@
 'use server';
 
-import { HttpError } from '@/shared/http/http-error';
+import { type ActionResult, toFailureResult } from '@/shared/action-result';
 import type { OptimizeCvRequest } from './contracts';
 import { analyzeCv, optimizeCvForJob } from './mutations';
 import type { CvAnalysisResult, CvOptimizationResult } from './mappers';
-
-// ─── Action types ─────────────────────────────────────────────────────────────
-
-export type AiActionCode =
-  | 'not_found'
-  | 'forbidden'
-  | 'unauthorized'
-  | 'unknown';
-
-export interface ActionSuccessResult<T = undefined> {
-  ok: true;
-  data?: T;
-}
-
-export interface ActionFailureResult {
-  ok: false;
-  code: AiActionCode;
-  message: string;
-}
-
-export type ActionResult<T = undefined> =
-  | ActionSuccessResult<T>
-  | ActionFailureResult;
-
-function toFailureResult(
-  error: unknown,
-  fallbackMessage: string
-): ActionFailureResult {
-  if (error instanceof HttpError) {
-    const message = error.serverMessage ?? error.message ?? fallbackMessage;
-    if (error.isNotFound) return { ok: false, code: 'not_found', message };
-    if (error.isForbidden) return { ok: false, code: 'forbidden', message };
-    if (error.isUnauthorized)
-      return { ok: false, code: 'unauthorized', message };
-  }
-  return { ok: false, code: 'unknown', message: fallbackMessage };
-}
 
 // ─── AI actions ───────────────────────────────────────────────────────────────
 

--- a/src/modules/ai/data/contracts.ts
+++ b/src/modules/ai/data/contracts.ts
@@ -1,0 +1,45 @@
+// ─── Response contracts ─────────────────────────────────────────────────────
+
+export interface CvIssueContract {
+  field: string;
+  severity: 'error' | 'warning' | 'info';
+  message: string;
+  suggestion?: string;
+}
+
+export interface CvSuggestionContract {
+  section: string;
+  current?: string;
+  suggested: string;
+  reason: string;
+}
+
+export interface SectionRecommendationContract {
+  section: string;
+  recommendation: string;
+  priority: 'high' | 'medium' | 'low';
+}
+
+export interface CvAnalysisResultContract {
+  overallScore: number;
+  grammarScore: number;
+  readabilityScore: number;
+  atsScore: number;
+  issues: CvIssueContract[];
+  suggestions: CvSuggestionContract[];
+  sectionRecommendations: SectionRecommendationContract[];
+}
+
+export interface CvOptimizationResultContract {
+  matchScore: number;
+  missingKeywords: string[];
+  presentKeywords: string[];
+  suggestions: CvSuggestionContract[];
+  sectionRecommendations: SectionRecommendationContract[];
+}
+
+// ─── Request contracts ──────────────────────────────────────────────────────
+
+export interface OptimizeCvRequest {
+  jobDescription: string;
+}

--- a/src/modules/ai/data/contracts.ts
+++ b/src/modules/ai/data/contracts.ts
@@ -1,23 +1,26 @@
 // ─── Response contracts ─────────────────────────────────────────────────────
 
 export interface CvIssueContract {
-  field: string;
-  severity: 'error' | 'warning' | 'info';
+  section: string;
+  type: 'grammar' | 'readability' | 'ats' | 'content';
+  severity: 'low' | 'medium' | 'high';
   message: string;
   suggestion?: string;
 }
 
 export interface CvSuggestionContract {
   section: string;
-  current?: string;
-  suggested: string;
-  reason: string;
+  type: 'improvement' | 'addition' | 'removal';
+  message: string;
+  originalText?: string;
+  suggestedText?: string;
 }
 
 export interface SectionRecommendationContract {
   section: string;
-  recommendation: string;
-  priority: 'high' | 'medium' | 'low';
+  action: 'add' | 'improve' | 'remove';
+  message: string;
+  priority: 'low' | 'medium' | 'high';
 }
 
 export interface CvAnalysisResultContract {
@@ -27,13 +30,11 @@ export interface CvAnalysisResultContract {
   atsScore: number;
   issues: CvIssueContract[];
   suggestions: CvSuggestionContract[];
-  sectionRecommendations: SectionRecommendationContract[];
 }
 
 export interface CvOptimizationResultContract {
   matchScore: number;
   missingKeywords: string[];
-  presentKeywords: string[];
   suggestions: CvSuggestionContract[];
   sectionRecommendations: SectionRecommendationContract[];
 }

--- a/src/modules/ai/data/mappers.ts
+++ b/src/modules/ai/data/mappers.ts
@@ -8,11 +8,15 @@ import type {
 
 // ─── Domain types ─────────────────────────────────────────────────────────────
 
-export type IssueSeverity = 'error' | 'warning' | 'info';
-export type RecommendationPriority = 'high' | 'medium' | 'low';
+export type IssueSeverity = 'low' | 'medium' | 'high';
+export type IssueType = 'grammar' | 'readability' | 'ats' | 'content';
+export type SuggestionType = 'improvement' | 'addition' | 'removal';
+export type RecommendationAction = 'add' | 'improve' | 'remove';
+export type RecommendationPriority = 'low' | 'medium' | 'high';
 
 export interface CvIssue {
-  field: string;
+  section: string;
+  type: IssueType;
   severity: IssueSeverity;
   message: string;
   suggestion: string | null;
@@ -20,14 +24,16 @@ export interface CvIssue {
 
 export interface CvSuggestion {
   section: string;
-  current: string | null;
-  suggested: string;
-  reason: string;
+  type: SuggestionType;
+  message: string;
+  originalText: string | null;
+  suggestedText: string | null;
 }
 
 export interface SectionRecommendation {
   section: string;
-  recommendation: string;
+  action: RecommendationAction;
+  message: string;
   priority: RecommendationPriority;
 }
 
@@ -38,13 +44,11 @@ export interface CvAnalysisResult {
   atsScore: number;
   issues: CvIssue[];
   suggestions: CvSuggestion[];
-  sectionRecommendations: SectionRecommendation[];
 }
 
 export interface CvOptimizationResult {
   matchScore: number;
   missingKeywords: string[];
-  presentKeywords: string[];
   suggestions: CvSuggestion[];
   sectionRecommendations: SectionRecommendation[];
 }
@@ -53,7 +57,8 @@ export interface CvOptimizationResult {
 
 function toIssue(c: CvIssueContract): CvIssue {
   return {
-    field: c.field,
+    section: c.section,
+    type: c.type,
     severity: c.severity,
     message: c.message,
     suggestion: c.suggestion ?? null,
@@ -63,9 +68,10 @@ function toIssue(c: CvIssueContract): CvIssue {
 function toSuggestion(c: CvSuggestionContract): CvSuggestion {
   return {
     section: c.section,
-    current: c.current ?? null,
-    suggested: c.suggested,
-    reason: c.reason,
+    type: c.type,
+    message: c.message,
+    originalText: c.originalText ?? null,
+    suggestedText: c.suggestedText ?? null,
   };
 }
 
@@ -74,7 +80,8 @@ function toRecommendation(
 ): SectionRecommendation {
   return {
     section: c.section,
-    recommendation: c.recommendation,
+    action: c.action,
+    message: c.message,
     priority: c.priority,
   };
 }
@@ -87,7 +94,6 @@ export function toCvAnalysis(c: CvAnalysisResultContract): CvAnalysisResult {
     atsScore: c.atsScore,
     issues: c.issues.map(toIssue),
     suggestions: c.suggestions.map(toSuggestion),
-    sectionRecommendations: c.sectionRecommendations.map(toRecommendation),
   };
 }
 
@@ -97,7 +103,6 @@ export function toCvOptimization(
   return {
     matchScore: c.matchScore,
     missingKeywords: c.missingKeywords,
-    presentKeywords: c.presentKeywords,
     suggestions: c.suggestions.map(toSuggestion),
     sectionRecommendations: c.sectionRecommendations.map(toRecommendation),
   };

--- a/src/modules/ai/data/mappers.ts
+++ b/src/modules/ai/data/mappers.ts
@@ -1,0 +1,104 @@
+import type {
+  CvAnalysisResultContract,
+  CvIssueContract,
+  CvOptimizationResultContract,
+  CvSuggestionContract,
+  SectionRecommendationContract,
+} from './contracts';
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+export type IssueSeverity = 'error' | 'warning' | 'info';
+export type RecommendationPriority = 'high' | 'medium' | 'low';
+
+export interface CvIssue {
+  field: string;
+  severity: IssueSeverity;
+  message: string;
+  suggestion: string | null;
+}
+
+export interface CvSuggestion {
+  section: string;
+  current: string | null;
+  suggested: string;
+  reason: string;
+}
+
+export interface SectionRecommendation {
+  section: string;
+  recommendation: string;
+  priority: RecommendationPriority;
+}
+
+export interface CvAnalysisResult {
+  overallScore: number;
+  grammarScore: number;
+  readabilityScore: number;
+  atsScore: number;
+  issues: CvIssue[];
+  suggestions: CvSuggestion[];
+  sectionRecommendations: SectionRecommendation[];
+}
+
+export interface CvOptimizationResult {
+  matchScore: number;
+  missingKeywords: string[];
+  presentKeywords: string[];
+  suggestions: CvSuggestion[];
+  sectionRecommendations: SectionRecommendation[];
+}
+
+// ─── Mappers ──────────────────────────────────────────────────────────────────
+
+function toIssue(c: CvIssueContract): CvIssue {
+  return {
+    field: c.field,
+    severity: c.severity,
+    message: c.message,
+    suggestion: c.suggestion ?? null,
+  };
+}
+
+function toSuggestion(c: CvSuggestionContract): CvSuggestion {
+  return {
+    section: c.section,
+    current: c.current ?? null,
+    suggested: c.suggested,
+    reason: c.reason,
+  };
+}
+
+function toRecommendation(
+  c: SectionRecommendationContract
+): SectionRecommendation {
+  return {
+    section: c.section,
+    recommendation: c.recommendation,
+    priority: c.priority,
+  };
+}
+
+export function toCvAnalysis(c: CvAnalysisResultContract): CvAnalysisResult {
+  return {
+    overallScore: c.overallScore,
+    grammarScore: c.grammarScore,
+    readabilityScore: c.readabilityScore,
+    atsScore: c.atsScore,
+    issues: c.issues.map(toIssue),
+    suggestions: c.suggestions.map(toSuggestion),
+    sectionRecommendations: c.sectionRecommendations.map(toRecommendation),
+  };
+}
+
+export function toCvOptimization(
+  c: CvOptimizationResultContract
+): CvOptimizationResult {
+  return {
+    matchScore: c.matchScore,
+    missingKeywords: c.missingKeywords,
+    presentKeywords: c.presentKeywords,
+    suggestions: c.suggestions.map(toSuggestion),
+    sectionRecommendations: c.sectionRecommendations.map(toRecommendation),
+  };
+}

--- a/src/modules/ai/data/mutations.ts
+++ b/src/modules/ai/data/mutations.ts
@@ -1,0 +1,40 @@
+import 'server-only';
+
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
+import type {
+  CvAnalysisResultContract,
+  CvOptimizationResultContract,
+  OptimizeCvRequest,
+} from './contracts';
+import {
+  toCvAnalysis,
+  toCvOptimization,
+  type CvAnalysisResult,
+  type CvOptimizationResult,
+} from './mappers';
+
+export async function analyzeCv(cvId: string): Promise<CvAnalysisResult> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.post<
+      CvAnalysisResultContract,
+      Record<string, never>
+    >(`ai/cv/${cvId}/analyze`, {}, { headers });
+
+    return toCvAnalysis(contract);
+  });
+}
+
+export async function optimizeCvForJob(
+  cvId: string,
+  body: OptimizeCvRequest
+): Promise<CvOptimizationResult> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.post<
+      CvOptimizationResultContract,
+      OptimizeCvRequest
+    >(`ai/cv/${cvId}/optimize`, body, { headers });
+
+    return toCvOptimization(contract);
+  });
+}

--- a/src/modules/interview/data/contracts.ts
+++ b/src/modules/interview/data/contracts.ts
@@ -1,0 +1,13 @@
+// ─── Response contracts ─────────────────────────────────────────────────────
+
+export type InterviewDifficultyContract = 'EASY' | 'MEDIUM' | 'HARD';
+
+export interface InterviewQuestionContract {
+  id: string;
+  question: string;
+  sampleAnswer?: string;
+  category: string;
+  role: string;
+  difficulty: InterviewDifficultyContract;
+  tips?: string;
+}

--- a/src/modules/interview/data/mappers.ts
+++ b/src/modules/interview/data/mappers.ts
@@ -1,0 +1,41 @@
+import type {
+  InterviewDifficultyContract,
+  InterviewQuestionContract,
+} from './contracts';
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+export type InterviewDifficulty = 'easy' | 'medium' | 'hard';
+
+export interface InterviewQuestion {
+  id: string;
+  question: string;
+  sampleAnswer: string | null;
+  category: string;
+  role: string;
+  difficulty: InterviewDifficulty;
+  tips: string | null;
+}
+
+// ─── Mappers ──────────────────────────────────────────────────────────────────
+
+const DIFFICULTY_MAP: Record<InterviewDifficultyContract, InterviewDifficulty> =
+  {
+    EASY: 'easy',
+    MEDIUM: 'medium',
+    HARD: 'hard',
+  };
+
+export function toInterviewQuestion(
+  c: InterviewQuestionContract
+): InterviewQuestion {
+  return {
+    id: c.id,
+    question: c.question,
+    sampleAnswer: c.sampleAnswer ?? null,
+    category: c.category,
+    role: c.role,
+    difficulty: DIFFICULTY_MAP[c.difficulty] ?? 'medium',
+    tips: c.tips ?? null,
+  };
+}

--- a/src/modules/interview/data/queries.ts
+++ b/src/modules/interview/data/queries.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import { apiClient } from '@/shared/http/api-client';
+import type { InterviewQuestionContract } from './contracts';
+import { toInterviewQuestion, type InterviewQuestion } from './mappers';
+
+export async function getInterviewQuestions(params?: {
+  role?: string;
+  category?: string;
+  difficulty?: string;
+  random?: boolean;
+  limit?: number;
+}): Promise<InterviewQuestion[]> {
+  const queryParams: Record<string, string | number | boolean> = {};
+  if (params?.role) queryParams.role = params.role;
+  if (params?.category) queryParams.category = params.category;
+  if (params?.difficulty) queryParams.difficulty = params.difficulty;
+  if (params?.random) queryParams.random = true;
+  if (params?.limit) queryParams.limit = params.limit;
+
+  const contracts = await apiClient.get<InterviewQuestionContract[]>(
+    'interview/questions',
+    { params: queryParams }
+  );
+
+  return contracts.map(toInterviewQuestion);
+}
+
+export async function getInterviewRoles(): Promise<string[]> {
+  return apiClient.get<string[]>('interview/roles');
+}
+
+export async function getInterviewCategories(): Promise<string[]> {
+  return apiClient.get<string[]>('interview/categories');
+}

--- a/src/modules/interview/data/queries.ts
+++ b/src/modules/interview/data/queries.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { apiClient } from '@/shared/http/api-client';
+import type { PaginatedResponse } from '@/shared/http/paginated-response';
 import type { InterviewQuestionContract } from './contracts';
 import { toInterviewQuestion, type InterviewQuestion } from './mappers';
 
@@ -18,12 +19,11 @@ export async function getInterviewQuestions(params?: {
   if (params?.random) queryParams.random = true;
   if (params?.limit) queryParams.limit = params.limit;
 
-  const contracts = await apiClient.get<InterviewQuestionContract[]>(
-    'interview/questions',
-    { params: queryParams }
-  );
+  const response = await apiClient.get<
+    PaginatedResponse<InterviewQuestionContract>
+  >('interview/questions', { params: queryParams });
 
-  return contracts.map(toInterviewQuestion);
+  return response.data.map(toInterviewQuestion);
 }
 
 export async function getInterviewRoles(): Promise<string[]> {

--- a/src/modules/jobs/data/actions.ts
+++ b/src/modules/jobs/data/actions.ts
@@ -1,0 +1,144 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { HttpError } from '@/shared/http/http-error';
+import type {
+  CreateJobNoteRequest,
+  CreateJobRequest,
+  UpdateJobRequest,
+  UpdateJobStatusRequest,
+} from './contracts';
+import {
+  createJob,
+  createJobNote,
+  deleteJob,
+  deleteJobNote,
+  updateJob,
+  updateJobStatus,
+} from './mutations';
+import type { Job, JobNote } from './mappers';
+
+// ─── Action types ─────────────────────────────────────────────────────────────
+
+export type JobActionCode =
+  | 'not_found'
+  | 'forbidden'
+  | 'unauthorized'
+  | 'unknown';
+
+export interface ActionSuccessResult<T = undefined> {
+  ok: true;
+  message?: string;
+  redirectTo?: string;
+  data?: T;
+}
+
+export interface ActionFailureResult {
+  ok: false;
+  code: JobActionCode;
+  message: string;
+}
+
+export type ActionResult<T = undefined> =
+  | ActionSuccessResult<T>
+  | ActionFailureResult;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function toFailureResult(
+  error: unknown,
+  fallbackMessage: string
+): ActionFailureResult {
+  if (error instanceof HttpError) {
+    const message = error.serverMessage ?? error.message ?? fallbackMessage;
+
+    if (error.isNotFound) return { ok: false, code: 'not_found', message };
+    if (error.isForbidden) return { ok: false, code: 'forbidden', message };
+    if (error.isUnauthorized)
+      return { ok: false, code: 'unauthorized', message };
+  }
+
+  return { ok: false, code: 'unknown', message: fallbackMessage };
+}
+
+// ─── Job actions ──────────────────────────────────────────────────────────────
+
+export async function createJobAction(
+  input: CreateJobRequest
+): Promise<ActionResult<Job>> {
+  try {
+    const job = await createJob(input);
+    revalidatePath('/jobs');
+
+    return { ok: true, data: job, message: 'Job added successfully.' };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to add the job.');
+  }
+}
+
+export async function updateJobAction(
+  id: string,
+  input: UpdateJobRequest
+): Promise<ActionResult<Job>> {
+  try {
+    const job = await updateJob(id, input);
+    revalidatePath('/jobs');
+
+    return { ok: true, data: job, message: 'Job updated.' };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to update the job.');
+  }
+}
+
+export async function updateJobStatusAction(
+  id: string,
+  input: UpdateJobStatusRequest
+): Promise<ActionResult<Job>> {
+  try {
+    const job = await updateJobStatus(id, input);
+    revalidatePath('/jobs');
+
+    return { ok: true, data: job, message: 'Status updated.' };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to update the job status.');
+  }
+}
+
+export async function deleteJobAction(id: string): Promise<ActionResult> {
+  try {
+    await deleteJob(id);
+    revalidatePath('/jobs');
+
+    return { ok: true, message: 'Job deleted.' };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to delete the job.');
+  }
+}
+
+export async function createJobNoteAction(
+  jobId: string,
+  input: CreateJobNoteRequest
+): Promise<ActionResult<JobNote>> {
+  try {
+    const note = await createJobNote(jobId, input);
+    revalidatePath(`/jobs/${jobId}`);
+
+    return { ok: true, data: note, message: 'Note added.' };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to add the note.');
+  }
+}
+
+export async function deleteJobNoteAction(
+  jobId: string,
+  noteId: string
+): Promise<ActionResult> {
+  try {
+    await deleteJobNote(jobId, noteId);
+    revalidatePath(`/jobs/${jobId}`);
+
+    return { ok: true, message: 'Note deleted.' };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to delete the note.');
+  }
+}

--- a/src/modules/jobs/data/actions.ts
+++ b/src/modules/jobs/data/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { HttpError } from '@/shared/http/http-error';
+import { type ActionResult, toFailureResult } from '@/shared/action-result';
 import type {
   CreateJobNoteRequest,
   CreateJobRequest,
@@ -17,49 +17,6 @@ import {
   updateJobStatus,
 } from './mutations';
 import type { Job, JobNote } from './mappers';
-
-// ─── Action types ─────────────────────────────────────────────────────────────
-
-export type JobActionCode =
-  | 'not_found'
-  | 'forbidden'
-  | 'unauthorized'
-  | 'unknown';
-
-export interface ActionSuccessResult<T = undefined> {
-  ok: true;
-  message?: string;
-  redirectTo?: string;
-  data?: T;
-}
-
-export interface ActionFailureResult {
-  ok: false;
-  code: JobActionCode;
-  message: string;
-}
-
-export type ActionResult<T = undefined> =
-  | ActionSuccessResult<T>
-  | ActionFailureResult;
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function toFailureResult(
-  error: unknown,
-  fallbackMessage: string
-): ActionFailureResult {
-  if (error instanceof HttpError) {
-    const message = error.serverMessage ?? error.message ?? fallbackMessage;
-
-    if (error.isNotFound) return { ok: false, code: 'not_found', message };
-    if (error.isForbidden) return { ok: false, code: 'forbidden', message };
-    if (error.isUnauthorized)
-      return { ok: false, code: 'unauthorized', message };
-  }
-
-  return { ok: false, code: 'unknown', message: fallbackMessage };
-}
 
 // ─── Job actions ──────────────────────────────────────────────────────────────
 

--- a/src/modules/jobs/data/contracts.ts
+++ b/src/modules/jobs/data/contracts.ts
@@ -1,0 +1,77 @@
+// ─── Shared ──────────────────────────────────────────────────────────────────
+
+export type JobStatusContract =
+  | 'SAVED'
+  | 'APPLIED'
+  | 'INTERVIEW'
+  | 'OFFER'
+  | 'REJECTED';
+
+// ─── Response contracts ─────────────────────────────────────────────────────
+
+export interface JobNoteResponseContract {
+  id: string;
+  content: string;
+  createdAt: string;
+}
+
+export interface JobResponseContract {
+  id: string;
+  title: string;
+  company: string;
+  url?: string;
+  location?: string;
+  isRemote: boolean;
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  status: JobStatusContract;
+  appliedAt?: string;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+  jobNotes?: JobNoteResponseContract[];
+}
+
+export interface JobStatsResponseContract {
+  total: number;
+  byStatus: Record<string, number>;
+  appliedThisWeek: number;
+  pendingInterviews: number;
+  activeOffers: number;
+}
+
+// ─── Request contracts ──────────────────────────────────────────────────────
+
+export interface CreateJobRequest {
+  title: string;
+  company: string;
+  url?: string;
+  location?: string;
+  isRemote?: boolean;
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  status?: JobStatusContract;
+  notes?: string;
+}
+
+export interface UpdateJobRequest {
+  title?: string;
+  company?: string;
+  url?: string;
+  location?: string;
+  isRemote?: boolean;
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  notes?: string;
+}
+
+export interface UpdateJobStatusRequest {
+  status: JobStatusContract;
+}
+
+export interface CreateJobNoteRequest {
+  content: string;
+}

--- a/src/modules/jobs/data/mappers.ts
+++ b/src/modules/jobs/data/mappers.ts
@@ -56,6 +56,14 @@ const STATUS_MAP: Record<JobStatusContract, JobStatus> = {
   REJECTED: 'rejected',
 };
 
+export const REVERSE_STATUS_MAP: Record<JobStatus, JobStatusContract> = {
+  saved: 'SAVED',
+  applied: 'APPLIED',
+  interview: 'INTERVIEW',
+  offer: 'OFFER',
+  rejected: 'REJECTED',
+};
+
 export function toJobNote(contract: JobNoteResponseContract): JobNote {
   return {
     id: contract.id,

--- a/src/modules/jobs/data/mappers.ts
+++ b/src/modules/jobs/data/mappers.ts
@@ -1,0 +1,95 @@
+import type {
+  JobNoteResponseContract,
+  JobResponseContract,
+  JobStatsResponseContract,
+  JobStatusContract,
+} from './contracts';
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+export type JobStatus =
+  | 'saved'
+  | 'applied'
+  | 'interview'
+  | 'offer'
+  | 'rejected';
+
+export interface JobNote {
+  id: string;
+  content: string;
+  createdAt: Date;
+}
+
+export interface Job {
+  id: string;
+  title: string;
+  company: string;
+  url: string | null;
+  location: string | null;
+  isRemote: boolean;
+  salaryMin: number | null;
+  salaryMax: number | null;
+  salaryCurrency: string | null;
+  status: JobStatus;
+  appliedAt: Date | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  jobNotes: JobNote[];
+}
+
+export interface JobStats {
+  total: number;
+  byStatus: Record<string, number>;
+  appliedThisWeek: number;
+  pendingInterviews: number;
+  activeOffers: number;
+}
+
+// ─── Mappers ──────────────────────────────────────────────────────────────────
+
+const STATUS_MAP: Record<JobStatusContract, JobStatus> = {
+  SAVED: 'saved',
+  APPLIED: 'applied',
+  INTERVIEW: 'interview',
+  OFFER: 'offer',
+  REJECTED: 'rejected',
+};
+
+export function toJobNote(contract: JobNoteResponseContract): JobNote {
+  return {
+    id: contract.id,
+    content: contract.content,
+    createdAt: new Date(contract.createdAt),
+  };
+}
+
+export function toJob(contract: JobResponseContract): Job {
+  return {
+    id: contract.id,
+    title: contract.title,
+    company: contract.company,
+    url: contract.url ?? null,
+    location: contract.location ?? null,
+    isRemote: contract.isRemote,
+    salaryMin: contract.salaryMin ?? null,
+    salaryMax: contract.salaryMax ?? null,
+    salaryCurrency: contract.salaryCurrency ?? null,
+    status: STATUS_MAP[contract.status] ?? 'saved',
+    appliedAt: contract.appliedAt ? new Date(contract.appliedAt) : null,
+    notes: contract.notes ?? null,
+    createdAt: new Date(contract.createdAt),
+    updatedAt: new Date(contract.updatedAt),
+    jobNotes: (contract.jobNotes ?? []).map(toJobNote),
+  };
+}
+
+export function toJobStats(contract: JobStatsResponseContract): JobStats {
+  return {
+    total: contract.total,
+    byStatus: contract.byStatus,
+    appliedThisWeek: contract.appliedThisWeek,
+    pendingInterviews: contract.pendingInterviews,
+    activeOffers: contract.activeOffers,
+  };
+}

--- a/src/modules/jobs/data/mutations.ts
+++ b/src/modules/jobs/data/mutations.ts
@@ -1,0 +1,81 @@
+import 'server-only';
+
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
+import type {
+  CreateJobNoteRequest,
+  CreateJobRequest,
+  JobNoteResponseContract,
+  JobResponseContract,
+  UpdateJobRequest,
+  UpdateJobStatusRequest,
+} from './contracts';
+import { toJob, toJobNote, type Job, type JobNote } from './mappers';
+
+export async function createJob(body: CreateJobRequest): Promise<Job> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.post<
+      JobResponseContract,
+      CreateJobRequest
+    >('jobs', body, { headers });
+
+    return toJob(contract);
+  });
+}
+
+export async function updateJob(
+  id: string,
+  body: UpdateJobRequest
+): Promise<Job> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.patch<
+      JobResponseContract,
+      UpdateJobRequest
+    >(`jobs/${id}`, body, { headers });
+
+    return toJob(contract);
+  });
+}
+
+export async function updateJobStatus(
+  id: string,
+  body: UpdateJobStatusRequest
+): Promise<Job> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.patch<
+      JobResponseContract,
+      UpdateJobStatusRequest
+    >(`jobs/${id}/status`, body, { headers });
+
+    return toJob(contract);
+  });
+}
+
+export async function deleteJob(id: string): Promise<void> {
+  return executeAuthenticatedRequest(async (headers) => {
+    await apiClient.delete(`jobs/${id}`, { headers });
+  });
+}
+
+export async function createJobNote(
+  jobId: string,
+  body: CreateJobNoteRequest
+): Promise<JobNote> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.post<
+      JobNoteResponseContract,
+      CreateJobNoteRequest
+    >(`jobs/${jobId}/notes`, body, { headers });
+
+    return toJobNote(contract);
+  });
+}
+
+export async function deleteJobNote(
+  jobId: string,
+  noteId: string
+): Promise<void> {
+  return executeAuthenticatedRequest(async (headers) => {
+    await apiClient.delete(`jobs/${jobId}/notes/${noteId}`, { headers });
+  });
+}

--- a/src/modules/jobs/data/queries.ts
+++ b/src/modules/jobs/data/queries.ts
@@ -1,0 +1,44 @@
+import 'server-only';
+
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
+import type {
+  JobResponseContract,
+  JobStatsResponseContract,
+} from './contracts';
+import { toJob, toJobStats, type Job, type JobStats } from './mappers';
+
+export async function getJobs(status?: string): Promise<Job[]> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const params: Record<string, string> = {};
+    if (status) params.status = status;
+
+    const contracts = await apiClient.get<JobResponseContract[]>('jobs', {
+      headers,
+      params,
+    });
+
+    return contracts.map(toJob);
+  });
+}
+
+export async function getJobById(id: string): Promise<Job> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.get<JobResponseContract>(`jobs/${id}`, {
+      headers,
+    });
+
+    return toJob(contract);
+  });
+}
+
+export async function getJobStats(): Promise<JobStats> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.get<JobStatsResponseContract>(
+      'jobs/stats',
+      { headers }
+    );
+
+    return toJobStats(contract);
+  });
+}

--- a/src/modules/jobs/data/queries.ts
+++ b/src/modules/jobs/data/queries.ts
@@ -2,6 +2,7 @@ import 'server-only';
 
 import { apiClient } from '@/shared/http/api-client';
 import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
+import type { PaginatedResponse } from '@/shared/http/paginated-response';
 import type {
   JobResponseContract,
   JobStatsResponseContract,
@@ -10,15 +11,17 @@ import { toJob, toJobStats, type Job, type JobStats } from './mappers';
 
 export async function getJobs(status?: string): Promise<Job[]> {
   return executeAuthenticatedRequest(async (headers) => {
-    const params: Record<string, string> = {};
+    const params: Record<string, string | number> = { limit: 200 };
     if (status) params.status = status;
 
-    const contracts = await apiClient.get<JobResponseContract[]>('jobs', {
+    const response = await apiClient.get<
+      PaginatedResponse<JobResponseContract>
+    >('jobs', {
       headers,
       params,
     });
 
-    return contracts.map(toJob);
+    return response.data.map(toJob);
   });
 }
 

--- a/src/modules/skills/data/actions.ts
+++ b/src/modules/skills/data/actions.ts
@@ -1,0 +1,71 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+import { HttpError } from '@/shared/http/http-error';
+import type { AssessSkillsRequest, UpdateProgressRequest } from './contracts';
+import { assessSkills, updateSkillProgress } from './mutations';
+import type { SkillAssessment, UserSkillProgress } from './mappers';
+
+// ─── Action types ─────────────────────────────────────────────────────────────
+
+export type SkillsActionCode =
+  | 'not_found'
+  | 'forbidden'
+  | 'unauthorized'
+  | 'unknown';
+
+export interface ActionSuccessResult<T = undefined> {
+  ok: true;
+  data?: T;
+  message?: string;
+}
+
+export interface ActionFailureResult {
+  ok: false;
+  code: SkillsActionCode;
+  message: string;
+}
+
+export type ActionResult<T = undefined> =
+  | ActionSuccessResult<T>
+  | ActionFailureResult;
+
+function toFailureResult(
+  error: unknown,
+  fallbackMessage: string
+): ActionFailureResult {
+  if (error instanceof HttpError) {
+    const message = error.serverMessage ?? error.message ?? fallbackMessage;
+    if (error.isNotFound) return { ok: false, code: 'not_found', message };
+    if (error.isForbidden) return { ok: false, code: 'forbidden', message };
+    if (error.isUnauthorized)
+      return { ok: false, code: 'unauthorized', message };
+  }
+  return { ok: false, code: 'unknown', message: fallbackMessage };
+}
+
+// ─── Skills actions ─────────────────────────────────────────────────────────
+
+export async function assessSkillsAction(
+  input: AssessSkillsRequest
+): Promise<ActionResult<SkillAssessment>> {
+  try {
+    const result = await assessSkills(input);
+    return { ok: true, data: result };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to assess your skills.');
+  }
+}
+
+export async function updateSkillProgressAction(
+  input: UpdateProgressRequest
+): Promise<ActionResult<UserSkillProgress>> {
+  try {
+    const progress = await updateSkillProgress(input);
+    revalidatePath('/skills');
+
+    return { ok: true, data: progress, message: 'Progress updated.' };
+  } catch (error) {
+    return toFailureResult(error, 'Unable to update your progress.');
+  }
+}

--- a/src/modules/skills/data/actions.ts
+++ b/src/modules/skills/data/actions.ts
@@ -1,54 +1,16 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { HttpError } from '@/shared/http/http-error';
+import { type ActionResult, toFailureResult } from '@/shared/action-result';
 import type { AssessSkillsRequest, UpdateProgressRequest } from './contracts';
 import { assessSkills, updateSkillProgress } from './mutations';
-import type { SkillAssessment, UserSkillProgress } from './mappers';
-
-// ─── Action types ─────────────────────────────────────────────────────────────
-
-export type SkillsActionCode =
-  | 'not_found'
-  | 'forbidden'
-  | 'unauthorized'
-  | 'unknown';
-
-export interface ActionSuccessResult<T = undefined> {
-  ok: true;
-  data?: T;
-  message?: string;
-}
-
-export interface ActionFailureResult {
-  ok: false;
-  code: SkillsActionCode;
-  message: string;
-}
-
-export type ActionResult<T = undefined> =
-  | ActionSuccessResult<T>
-  | ActionFailureResult;
-
-function toFailureResult(
-  error: unknown,
-  fallbackMessage: string
-): ActionFailureResult {
-  if (error instanceof HttpError) {
-    const message = error.serverMessage ?? error.message ?? fallbackMessage;
-    if (error.isNotFound) return { ok: false, code: 'not_found', message };
-    if (error.isForbidden) return { ok: false, code: 'forbidden', message };
-    if (error.isUnauthorized)
-      return { ok: false, code: 'unauthorized', message };
-  }
-  return { ok: false, code: 'unknown', message: fallbackMessage };
-}
+import type { SkillGapResult, UserSkillProgress } from './mappers';
 
 // ─── Skills actions ─────────────────────────────────────────────────────────
 
 export async function assessSkillsAction(
   input: AssessSkillsRequest
-): Promise<ActionResult<SkillAssessment>> {
+): Promise<ActionResult<SkillGapResult>> {
   try {
     const result = await assessSkills(input);
     return { ok: true, data: result };

--- a/src/modules/skills/data/contracts.ts
+++ b/src/modules/skills/data/contracts.ts
@@ -1,0 +1,76 @@
+// ─── Response contracts ─────────────────────────────────────────────────────
+
+export interface SkillCategoryContract {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string;
+}
+
+export interface RoleSkillMapContract {
+  role: string;
+  skillName: string;
+  category: SkillCategoryContract;
+  importance: number;
+}
+
+export interface SkillGapContract {
+  skillName: string;
+  category: string;
+  importance: number;
+  currentLevel: number;
+  requiredLevel: number;
+  gap: number;
+}
+
+export interface SkillAssessmentContract {
+  role: string;
+  readinessScore: number;
+  gaps: SkillGapContract[];
+}
+
+export interface UserSkillProgressContract {
+  id: string;
+  skillName: string;
+  level: number;
+  status: string;
+  startedAt?: string;
+  completedAt?: string;
+}
+
+export interface LearningResourceContract {
+  id: string;
+  skillName: string;
+  title: string;
+  url: string;
+  platform?: string;
+  difficulty?: string;
+  duration?: string;
+  isFree: boolean;
+}
+
+export interface RoadmapPhaseContract {
+  phase: string;
+  skills: Array<{
+    skillName: string;
+    importance: number;
+    currentLevel: number;
+    targetLevel: number;
+  }>;
+}
+
+// ─── Request contracts ──────────────────────────────────────────────────────
+
+export interface AssessSkillsRequest {
+  role: string;
+  skills: Array<{
+    name: string;
+    level: number;
+  }>;
+}
+
+export interface UpdateProgressRequest {
+  skillName: string;
+  level: number;
+  status?: string;
+}

--- a/src/modules/skills/data/contracts.ts
+++ b/src/modules/skills/data/contracts.ts
@@ -7,26 +7,20 @@ export interface SkillCategoryContract {
   icon?: string;
 }
 
-export interface RoleSkillMapContract {
-  role: string;
-  skillName: string;
-  category: SkillCategoryContract;
-  importance: number;
-}
-
-export interface SkillGapContract {
+export interface SkillAssessmentItemContract {
   skillName: string;
   category: string;
   importance: number;
-  currentLevel: number;
-  requiredLevel: number;
-  gap: number;
+  hasSkill: boolean;
+  userLevel?: number;
 }
 
-export interface SkillAssessmentContract {
-  role: string;
-  readinessScore: number;
-  gaps: SkillGapContract[];
+export interface SkillGapResponseContract {
+  targetRole: string;
+  overallReadiness: number;
+  requiredSkills: SkillAssessmentItemContract[];
+  strengths: string[];
+  gaps: string[];
 }
 
 export interface UserSkillProgressContract {
@@ -43,34 +37,42 @@ export interface LearningResourceContract {
   skillName: string;
   title: string;
   url: string;
-  platform?: string;
-  difficulty?: string;
+  platform: string;
+  difficulty: string;
   duration?: string;
   isFree: boolean;
 }
 
-export interface RoadmapPhaseContract {
+export interface RoadmapSkillContract {
+  skillName: string;
+  importance: number;
+  status: string;
+  level: number;
+  resources: LearningResourceContract[];
+}
+
+export interface RoadmapMilestoneContract {
   phase: string;
-  skills: Array<{
-    skillName: string;
-    importance: number;
-    currentLevel: number;
-    targetLevel: number;
-  }>;
+  skills: RoadmapSkillContract[];
+  description: string;
+}
+
+export interface LearningRoadmapContract {
+  targetRole: string;
+  totalSkills: number;
+  completedSkills: number;
+  milestones: RoadmapMilestoneContract[];
 }
 
 // ─── Request contracts ──────────────────────────────────────────────────────
 
 export interface AssessSkillsRequest {
-  role: string;
-  skills: Array<{
-    name: string;
-    level: number;
-  }>;
+  targetRole: string;
+  currentSkills?: string[];
 }
 
 export interface UpdateProgressRequest {
   skillName: string;
-  level: number;
+  level?: number;
   status?: string;
 }

--- a/src/modules/skills/data/mappers.ts
+++ b/src/modules/skills/data/mappers.ts
@@ -1,0 +1,127 @@
+import type {
+  LearningResourceContract,
+  RoadmapPhaseContract,
+  SkillAssessmentContract,
+  SkillCategoryContract,
+  SkillGapContract,
+  UserSkillProgressContract,
+} from './contracts';
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+export interface SkillCategory {
+  id: string;
+  name: string;
+  description: string | null;
+  icon: string | null;
+}
+
+export interface SkillGap {
+  skillName: string;
+  category: string;
+  importance: number;
+  currentLevel: number;
+  requiredLevel: number;
+  gap: number;
+}
+
+export interface SkillAssessment {
+  role: string;
+  readinessScore: number;
+  gaps: SkillGap[];
+}
+
+export interface UserSkillProgress {
+  id: string;
+  skillName: string;
+  level: number;
+  status: string;
+  startedAt: Date | null;
+  completedAt: Date | null;
+}
+
+export interface LearningResource {
+  id: string;
+  skillName: string;
+  title: string;
+  url: string;
+  platform: string | null;
+  difficulty: string | null;
+  duration: string | null;
+  isFree: boolean;
+}
+
+export interface RoadmapPhase {
+  phase: string;
+  skills: Array<{
+    skillName: string;
+    importance: number;
+    currentLevel: number;
+    targetLevel: number;
+  }>;
+}
+
+// ─── Mappers ──────────────────────────────────────────────────────────────────
+
+export function toSkillCategory(c: SkillCategoryContract): SkillCategory {
+  return {
+    id: c.id,
+    name: c.name,
+    description: c.description ?? null,
+    icon: c.icon ?? null,
+  };
+}
+
+function toSkillGap(c: SkillGapContract): SkillGap {
+  return {
+    skillName: c.skillName,
+    category: c.category,
+    importance: c.importance,
+    currentLevel: c.currentLevel,
+    requiredLevel: c.requiredLevel,
+    gap: c.gap,
+  };
+}
+
+export function toSkillAssessment(c: SkillAssessmentContract): SkillAssessment {
+  return {
+    role: c.role,
+    readinessScore: c.readinessScore,
+    gaps: c.gaps.map(toSkillGap),
+  };
+}
+
+export function toUserSkillProgress(
+  c: UserSkillProgressContract
+): UserSkillProgress {
+  return {
+    id: c.id,
+    skillName: c.skillName,
+    level: c.level,
+    status: c.status,
+    startedAt: c.startedAt ? new Date(c.startedAt) : null,
+    completedAt: c.completedAt ? new Date(c.completedAt) : null,
+  };
+}
+
+export function toLearningResource(
+  c: LearningResourceContract
+): LearningResource {
+  return {
+    id: c.id,
+    skillName: c.skillName,
+    title: c.title,
+    url: c.url,
+    platform: c.platform ?? null,
+    difficulty: c.difficulty ?? null,
+    duration: c.duration ?? null,
+    isFree: c.isFree,
+  };
+}
+
+export function toRoadmapPhase(c: RoadmapPhaseContract): RoadmapPhase {
+  return {
+    phase: c.phase,
+    skills: c.skills,
+  };
+}

--- a/src/modules/skills/data/mappers.ts
+++ b/src/modules/skills/data/mappers.ts
@@ -1,9 +1,10 @@
 import type {
   LearningResourceContract,
-  RoadmapPhaseContract,
-  SkillAssessmentContract,
+  RoadmapMilestoneContract,
+  LearningRoadmapContract,
+  SkillAssessmentItemContract,
+  SkillGapResponseContract,
   SkillCategoryContract,
-  SkillGapContract,
   UserSkillProgressContract,
 } from './contracts';
 
@@ -16,19 +17,20 @@ export interface SkillCategory {
   icon: string | null;
 }
 
-export interface SkillGap {
+export interface SkillAssessmentItem {
   skillName: string;
   category: string;
   importance: number;
-  currentLevel: number;
-  requiredLevel: number;
-  gap: number;
+  hasSkill: boolean;
+  userLevel: number | null;
 }
 
-export interface SkillAssessment {
-  role: string;
-  readinessScore: number;
-  gaps: SkillGap[];
+export interface SkillGapResult {
+  targetRole: string;
+  overallReadiness: number;
+  requiredSkills: SkillAssessmentItem[];
+  strengths: string[];
+  gaps: string[];
 }
 
 export interface UserSkillProgress {
@@ -45,20 +47,29 @@ export interface LearningResource {
   skillName: string;
   title: string;
   url: string;
-  platform: string | null;
-  difficulty: string | null;
+  platform: string;
+  difficulty: string;
   duration: string | null;
   isFree: boolean;
 }
 
-export interface RoadmapPhase {
+export interface RoadmapMilestone {
   phase: string;
+  description: string;
   skills: Array<{
     skillName: string;
     importance: number;
-    currentLevel: number;
-    targetLevel: number;
+    status: string;
+    level: number;
+    resources: LearningResource[];
   }>;
+}
+
+export interface LearningRoadmap {
+  targetRole: string;
+  totalSkills: number;
+  completedSkills: number;
+  milestones: RoadmapMilestone[];
 }
 
 // ─── Mappers ──────────────────────────────────────────────────────────────────
@@ -72,22 +83,25 @@ export function toSkillCategory(c: SkillCategoryContract): SkillCategory {
   };
 }
 
-function toSkillGap(c: SkillGapContract): SkillGap {
+function toSkillAssessmentItem(
+  c: SkillAssessmentItemContract
+): SkillAssessmentItem {
   return {
     skillName: c.skillName,
     category: c.category,
     importance: c.importance,
-    currentLevel: c.currentLevel,
-    requiredLevel: c.requiredLevel,
-    gap: c.gap,
+    hasSkill: c.hasSkill,
+    userLevel: c.userLevel ?? null,
   };
 }
 
-export function toSkillAssessment(c: SkillAssessmentContract): SkillAssessment {
+export function toSkillGapResult(c: SkillGapResponseContract): SkillGapResult {
   return {
-    role: c.role,
-    readinessScore: c.readinessScore,
-    gaps: c.gaps.map(toSkillGap),
+    targetRole: c.targetRole,
+    overallReadiness: c.overallReadiness,
+    requiredSkills: c.requiredSkills.map(toSkillAssessmentItem),
+    strengths: c.strengths,
+    gaps: c.gaps,
   };
 }
 
@@ -112,16 +126,34 @@ export function toLearningResource(
     skillName: c.skillName,
     title: c.title,
     url: c.url,
-    platform: c.platform ?? null,
-    difficulty: c.difficulty ?? null,
+    platform: c.platform,
+    difficulty: c.difficulty,
     duration: c.duration ?? null,
     isFree: c.isFree,
   };
 }
 
-export function toRoadmapPhase(c: RoadmapPhaseContract): RoadmapPhase {
+export function toRoadmapMilestone(
+  c: RoadmapMilestoneContract
+): RoadmapMilestone {
   return {
     phase: c.phase,
-    skills: c.skills,
+    description: c.description,
+    skills: c.skills.map((s) => ({
+      skillName: s.skillName,
+      importance: s.importance,
+      status: s.status,
+      level: s.level,
+      resources: s.resources.map(toLearningResource),
+    })),
+  };
+}
+
+export function toLearningRoadmap(c: LearningRoadmapContract): LearningRoadmap {
+  return {
+    targetRole: c.targetRole,
+    totalSkills: c.totalSkills,
+    completedSkills: c.completedSkills,
+    milestones: c.milestones.map(toRoadmapMilestone),
   };
 }

--- a/src/modules/skills/data/mutations.ts
+++ b/src/modules/skills/data/mutations.ts
@@ -4,26 +4,26 @@ import { apiClient } from '@/shared/http/api-client';
 import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
 import type {
   AssessSkillsRequest,
-  SkillAssessmentContract,
+  SkillGapResponseContract,
   UpdateProgressRequest,
   UserSkillProgressContract,
 } from './contracts';
 import {
-  toSkillAssessment,
+  toSkillGapResult,
   toUserSkillProgress,
-  type SkillAssessment,
+  type SkillGapResult,
   type UserSkillProgress,
 } from './mappers';
 
 export async function assessSkills(
   body: AssessSkillsRequest
-): Promise<SkillAssessment> {
+): Promise<SkillGapResult> {
   return executeAuthenticatedRequest(async (headers) => {
     const contract = await apiClient.post<
-      SkillAssessmentContract,
+      SkillGapResponseContract,
       AssessSkillsRequest
     >('skills/assess', body, { headers });
-    return toSkillAssessment(contract);
+    return toSkillGapResult(contract);
   });
 }
 

--- a/src/modules/skills/data/mutations.ts
+++ b/src/modules/skills/data/mutations.ts
@@ -1,0 +1,40 @@
+import 'server-only';
+
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
+import type {
+  AssessSkillsRequest,
+  SkillAssessmentContract,
+  UpdateProgressRequest,
+  UserSkillProgressContract,
+} from './contracts';
+import {
+  toSkillAssessment,
+  toUserSkillProgress,
+  type SkillAssessment,
+  type UserSkillProgress,
+} from './mappers';
+
+export async function assessSkills(
+  body: AssessSkillsRequest
+): Promise<SkillAssessment> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.post<
+      SkillAssessmentContract,
+      AssessSkillsRequest
+    >('skills/assess', body, { headers });
+    return toSkillAssessment(contract);
+  });
+}
+
+export async function updateSkillProgress(
+  body: UpdateProgressRequest
+): Promise<UserSkillProgress> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.patch<
+      UserSkillProgressContract,
+      UpdateProgressRequest
+    >('skills/progress', body, { headers });
+    return toUserSkillProgress(contract);
+  });
+}

--- a/src/modules/skills/data/queries.ts
+++ b/src/modules/skills/data/queries.ts
@@ -1,0 +1,67 @@
+import 'server-only';
+
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
+import type {
+  LearningResourceContract,
+  RoadmapPhaseContract,
+  SkillCategoryContract,
+  UserSkillProgressContract,
+} from './contracts';
+import {
+  toLearningResource,
+  toRoadmapPhase,
+  toSkillCategory,
+  toUserSkillProgress,
+  type LearningResource,
+  type RoadmapPhase,
+  type SkillCategory,
+  type UserSkillProgress,
+} from './mappers';
+
+export async function getSkillCategories(): Promise<SkillCategory[]> {
+  const contracts =
+    await apiClient.get<SkillCategoryContract[]>('skills/categories');
+  return contracts.map(toSkillCategory);
+}
+
+export async function getSkillRoles(): Promise<string[]> {
+  return apiClient.get<string[]>('skills/roles');
+}
+
+export async function getResources(
+  skill?: string,
+  difficulty?: string
+): Promise<LearningResource[]> {
+  const params: Record<string, string> = {};
+  if (skill) params.skill = skill;
+  if (difficulty) params.difficulty = difficulty;
+
+  const contracts = await apiClient.get<LearningResourceContract[]>(
+    'skills/resources',
+    { params }
+  );
+  return contracts.map(toLearningResource);
+}
+
+export async function getUserProgress(): Promise<UserSkillProgress[]> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contracts = await apiClient.get<UserSkillProgressContract[]>(
+      'skills/progress',
+      { headers }
+    );
+    return contracts.map(toUserSkillProgress);
+  });
+}
+
+export async function getLearningRoadmap(
+  role: string
+): Promise<RoadmapPhase[]> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contracts = await apiClient.get<RoadmapPhaseContract[]>(
+      'skills/roadmap',
+      { headers, params: { role } }
+    );
+    return contracts.map(toRoadmapPhase);
+  });
+}

--- a/src/modules/skills/data/queries.ts
+++ b/src/modules/skills/data/queries.ts
@@ -4,17 +4,17 @@ import { apiClient } from '@/shared/http/api-client';
 import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
 import type {
   LearningResourceContract,
-  RoadmapPhaseContract,
+  LearningRoadmapContract,
   SkillCategoryContract,
   UserSkillProgressContract,
 } from './contracts';
 import {
   toLearningResource,
-  toRoadmapPhase,
+  toLearningRoadmap,
   toSkillCategory,
   toUserSkillProgress,
   type LearningResource,
-  type RoadmapPhase,
+  type LearningRoadmap,
   type SkillCategory,
   type UserSkillProgress,
 } from './mappers';
@@ -56,12 +56,12 @@ export async function getUserProgress(): Promise<UserSkillProgress[]> {
 
 export async function getLearningRoadmap(
   role: string
-): Promise<RoadmapPhase[]> {
+): Promise<LearningRoadmap> {
   return executeAuthenticatedRequest(async (headers) => {
-    const contracts = await apiClient.get<RoadmapPhaseContract[]>(
+    const contract = await apiClient.get<LearningRoadmapContract>(
       'skills/roadmap',
       { headers, params: { role } }
     );
-    return contracts.map(toRoadmapPhase);
+    return toLearningRoadmap(contract);
   });
 }

--- a/src/shared/action-result.ts
+++ b/src/shared/action-result.ts
@@ -1,0 +1,36 @@
+import { HttpError } from '@/shared/http/http-error';
+
+export type ActionCode = 'not_found' | 'forbidden' | 'unauthorized' | 'unknown';
+
+export interface ActionSuccessResult<T = undefined> {
+  ok: true;
+  data?: T;
+  message?: string;
+  redirectTo?: string;
+}
+
+export interface ActionFailureResult {
+  ok: false;
+  code: ActionCode;
+  message: string;
+}
+
+export type ActionResult<T = undefined> =
+  | ActionSuccessResult<T>
+  | ActionFailureResult;
+
+export function toFailureResult(
+  error: unknown,
+  fallbackMessage: string
+): ActionFailureResult {
+  if (error instanceof HttpError) {
+    const message = error.serverMessage ?? error.message ?? fallbackMessage;
+
+    if (error.isNotFound) return { ok: false, code: 'not_found', message };
+    if (error.isForbidden) return { ok: false, code: 'forbidden', message };
+    if (error.isUnauthorized)
+      return { ok: false, code: 'unauthorized', message };
+  }
+
+  return { ok: false, code: 'unknown', message: fallbackMessage };
+}

--- a/src/shared/http/paginated-response.ts
+++ b/src/shared/http/paginated-response.ts
@@ -1,0 +1,13 @@
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  hasNext: boolean;
+  hasPrev: boolean;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  meta: PaginationMeta;
+}


### PR DESCRIPTION
## Summary

Implements all frontend pages and data layers for PrismaCV platform features, integrating with the backend PR (Integral-X/prismacv-backend#162).

## What's Implemented

### 1. Jobs Tracker Page (`/jobs`)
- **Kanban board view**: 5 status columns (Saved, Applied, Interview, Offer, Rejected) with job cards
- **List view**: alternative tabular display
- **Stats dashboard**: total jobs, applied this week, pending interviews, active offers
- **Add job dialog**: form with title, company, URL, location, salary, remote toggle, status, notes
- **Inline status change**: Select dropdown per job card
- **Delete functionality**: with confirmation
- Full REST integration (no WebSockets)

### 2. Skills Assessment Page (`/skills`)
- **Category overview**: cards for each skill category with descriptions and icons
- **Assessment form**: role selector + skill input sliders
- **Readiness score**: progress bar visualization with percentage
- **Skill gaps display**: strengths vs gaps for target role
- Learning resources integration

### 3. Interview Prep Page (`/interview`)
- **Filters**: role, category, difficulty dropdowns
- **Shuffle mode**: randomize question order for practice
- **Practice mode**: card-by-card navigation with show/hide answer toggle
- **Question cards**: collapsible with sample answers and tips badges

### 4. AI Integration (Data Layer)
- Provider-agnostic CV analysis actions
- Job description optimization mutations
- Server actions for seamless SSR integration

### Data Architecture
Each module follows the established pattern:
- `contracts.ts` — Zod schemas + TypeScript types
- `mappers.ts` — API ↔ domain model transformations
- `queries.ts` — server-side data fetching
- `mutations.ts` — API mutation functions
- `actions.ts` — Next.js server actions with ActionResult pattern

### Navigation
- Authenticated routes: Dashboard, Jobs, Skills, Interview
- Public routes: Templates, Pricing, FAQ
- Conditional rendering based on auth state and current page

### UI Components (7 new shadcn/ui)
- Dialog, Select, Tabs, Progress, Slider, Collapsible, Label

### E2E Tests
- Protected routes redirect to login for unauthenticated users
- Query param preservation in redirects
- Navigation link visibility tests

### Middleware
- Added `/jobs`, `/skills`, `/interview` to protected route prefixes