### PR TITLE
fix: wire onboarding flows to real APIs

### DIFF
--- a/src/app/(site)/onboarding/import-linkedin/import-linkedin-page-client.tsx
+++ b/src/app/(site)/onboarding/import-linkedin/import-linkedin-page-client.tsx
@@ -8,23 +8,36 @@ import { WavyPattern } from '@/components/common/WavyPattern';
 import { LinkedInImport } from '@/components/pages/onboarding/LinkedInImport';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
+import { importLinkedInProfileAction } from '@/modules/cv/data/actions';
 
 export function ImportLinkedInPageClient() {
   const router = useRouter();
   const [importedUrl, setImportedUrl] = React.useState<string | null>(null);
+  const [importId, setImportId] = React.useState<string | null>(null);
 
-  const handleImport = (url: string) => {
+  const handleImportFn = async (url: string): Promise<{ importId: string }> => {
+    const result = await importLinkedInProfileAction(url);
+    if (!result.ok) {
+      throw new Error(result.message);
+    }
+    return result.data!;
+  };
+
+  const handleImport = (url: string, id: string) => {
     setImportedUrl(url);
+    setImportId(id);
   };
 
   const handleRemove = () => {
     setImportedUrl(null);
+    setImportId(null);
   };
 
   const handleContinue = () => {
-    if (importedUrl) {
-      // Navigate to template selection (Step 3)
-      router.push('/onboarding/select-template');
+    if (importedUrl && importId) {
+      router.push(
+        `/onboarding/select-template?importId=${encodeURIComponent(importId)}`
+      );
     }
   };
 
@@ -33,8 +46,7 @@ export function ImportLinkedInPageClient() {
   };
 
   const handleSkip = () => {
-    // TODO: Navigate to manual entry or skip this step
-    // router.push('/onboarding/manual-entry');
+    router.push('/onboarding/select-template');
   };
 
   return (
@@ -69,7 +81,11 @@ export function ImportLinkedInPageClient() {
 
           {/* LinkedIn Import Component */}
           <div className='mb-8 px-4'>
-            <LinkedInImport onImport={handleImport} onRemove={handleRemove} />
+            <LinkedInImport
+              onImport={handleImport}
+              onRemove={handleRemove}
+              importFn={handleImportFn}
+            />
           </div>
 
           {/* Action Buttons */}

--- a/src/app/(site)/onboarding/import-linkedin/import-linkedin-page-client.tsx
+++ b/src/app/(site)/onboarding/import-linkedin/import-linkedin-page-client.tsx
@@ -23,9 +23,9 @@ export function ImportLinkedInPageClient() {
     return result.data!;
   };
 
-  const handleImport = (url: string, id: string) => {
+  const handleImport = (url: string, id?: string) => {
     setImportedUrl(url);
-    setImportId(id);
+    setImportId(id ?? null);
   };
 
   const handleRemove = () => {

--- a/src/app/(site)/onboarding/import-linkedin/import-linkedin-page-client.tsx
+++ b/src/app/(site)/onboarding/import-linkedin/import-linkedin-page-client.tsx
@@ -92,7 +92,7 @@ export function ImportLinkedInPageClient() {
           <div className='flex flex-col sm:flex-row gap-4 justify-center items-center px-4'>
             <Button
               onClick={handleContinue}
-              disabled={!importedUrl}
+              disabled={!importedUrl || !importId}
               className='bg-primary text-primary-foreground hover:bg-primary/90 px-8 py-6 rounded-md text-base font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed w-full sm:w-auto'
             >
               Continue

--- a/src/app/(site)/onboarding/select-template/select-template-page-client.tsx
+++ b/src/app/(site)/onboarding/select-template/select-template-page-client.tsx
@@ -1,18 +1,23 @@
 'use client';
 
 import * as React from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Footer } from '@/components/common/Footer';
 import { OnboardingStepper } from '@/components/pages/onboarding/OnboardingStepper';
 import { WavyPattern } from '@/components/common/WavyPattern';
 import { TemplateSelector } from '@/components/pages/onboarding/TemplateSelector';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
-import { createCvAction } from '@/modules/cv/data/actions';
+import {
+  createCvAction,
+  importLinkedInToCvAction,
+} from '@/modules/cv/data/actions';
 import { toast } from 'sonner';
 
 export function SelectTemplatePageClient() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const importId = searchParams.get('importId');
   const [selectedTemplate, setSelectedTemplate] = React.useState<string | null>(
     null
   );
@@ -26,10 +31,16 @@ export function SelectTemplatePageClient() {
     if (!selectedTemplate) return;
 
     startTransition(async () => {
-      const result = await createCvAction({
-        title: 'My CV',
-        templateId: selectedTemplate,
-      });
+      const result = importId
+        ? await importLinkedInToCvAction({
+            importId,
+            title: 'My CV',
+            templateId: selectedTemplate,
+          })
+        : await createCvAction({
+            title: 'My CV',
+            templateId: selectedTemplate,
+          });
 
       if (result.ok && result.redirectTo) {
         router.push(result.redirectTo);

--- a/src/app/(site)/onboarding/upload-cv/upload-cv-page-client.tsx
+++ b/src/app/(site)/onboarding/upload-cv/upload-cv-page-client.tsx
@@ -33,8 +33,7 @@ export function UploadCVPageClient() {
   };
 
   const handleSkip = () => {
-    // TODO: Navigate to manual entry or skip this step
-    // router.push('/onboarding/manual-entry');
+    router.push('/onboarding/select-template');
   };
 
   return (

--- a/src/components/pages/onboarding/LinkedInImport/LinkedInImport.tsx
+++ b/src/components/pages/onboarding/LinkedInImport/LinkedInImport.tsx
@@ -71,6 +71,10 @@ export const LinkedInImport = ({
         setState('success');
         onImport?.(normalizedUrl, importId);
       } catch (error) {
+        if (errorResetTimeoutRef.current !== null) {
+          clearTimeout(errorResetTimeoutRef.current);
+          errorResetTimeoutRef.current = null;
+        }
         setState('error');
         setErrorMessage(
           error instanceof Error

--- a/src/components/pages/onboarding/LinkedInImport/LinkedInImport.tsx
+++ b/src/components/pages/onboarding/LinkedInImport/LinkedInImport.tsx
@@ -8,7 +8,6 @@ import {
   normalizeLinkedInUrl,
   extractLinkedInDisplayName,
 } from '../shared/utils/urlValidation';
-import { useProgressSimulation } from '../shared/hooks/useProgressSimulation';
 import type { ImportState } from '../shared/utils/stateStyles';
 import { LinkedInImportSuccess } from './LinkedInImportSuccess';
 import { LinkedInImportProgress } from './LinkedInImportProgress';
@@ -17,14 +16,15 @@ import { LinkedInImportForm } from './LinkedInImportForm';
 export const LinkedInImport = ({
   onImport,
   onRemove,
+  importFn,
   className,
 }: LinkedInImportProps) => {
   const [state, setState] = React.useState<ImportState>('idle');
   const [linkedInUrl, setLinkedInUrl] = React.useState<string>('');
   const [errorMessage, setErrorMessage] = React.useState<string>('');
+  const [progress, setProgress] = React.useState(0);
   const [importedProfile, setImportedProfile] =
     React.useState<ImportedProfile | null>(null);
-  const pendingUrlRef = React.useRef<string | null>(null);
   const errorResetTimeoutRef = React.useRef<ReturnType<
     typeof setTimeout
   > | null>(null);
@@ -38,27 +38,7 @@ export const LinkedInImport = ({
     };
   }, []);
 
-  const {
-    progress,
-    start: startProgress,
-    reset: resetProgress,
-  } = useProgressSimulation({
-    onComplete: () => {
-      if (pendingUrlRef.current) {
-        const normalizedUrl = normalizeLinkedInUrl(pendingUrlRef.current);
-        const displayName = extractLinkedInDisplayName(normalizedUrl);
-        setImportedProfile({
-          url: normalizedUrl,
-          displayName,
-        });
-        setState('success');
-        onImport?.(normalizedUrl);
-        pendingUrlRef.current = null;
-      }
-    },
-  });
-
-  const handleImport = () => {
+  const handleImport = async () => {
     const validation = validateLinkedInUrl(linkedInUrl);
 
     if (!validation.valid) {
@@ -77,15 +57,48 @@ export const LinkedInImport = ({
     }
 
     setState('importing');
-    pendingUrlRef.current = linkedInUrl;
-    startProgress();
+    setProgress(20);
+
+    const normalizedUrl = normalizeLinkedInUrl(linkedInUrl);
+
+    if (importFn) {
+      try {
+        setProgress(50);
+        const { importId } = await importFn(normalizedUrl);
+        setProgress(100);
+        const displayName = extractLinkedInDisplayName(normalizedUrl);
+        setImportedProfile({ url: normalizedUrl, displayName, importId });
+        setState('success');
+        onImport?.(normalizedUrl, importId);
+      } catch (error) {
+        setState('error');
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : 'Failed to import LinkedIn profile. Please try again.'
+        );
+        setProgress(0);
+        errorResetTimeoutRef.current = setTimeout(() => {
+          errorResetTimeoutRef.current = null;
+          setState('idle');
+          setErrorMessage('');
+        }, ERROR_DISPLAY_DURATION_MS);
+      }
+    } else {
+      // Fallback: no importFn provided, just validate URL and report success
+      const displayName = extractLinkedInDisplayName(normalizedUrl);
+      setProgress(100);
+      setImportedProfile({ url: normalizedUrl, displayName, importId: '' });
+      setState('success');
+      onImport?.(normalizedUrl, '');
+    }
   };
 
   const handleRemove = () => {
     setImportedProfile(null);
     setLinkedInUrl('');
     setState('idle');
-    resetProgress();
+    setProgress(0);
     onRemove?.();
   };
 

--- a/src/components/pages/onboarding/LinkedInImport/LinkedInImport.tsx
+++ b/src/components/pages/onboarding/LinkedInImport/LinkedInImport.tsx
@@ -92,9 +92,9 @@ export const LinkedInImport = ({
       // Fallback: no importFn provided, just validate URL and report success
       const displayName = extractLinkedInDisplayName(normalizedUrl);
       setProgress(100);
-      setImportedProfile({ url: normalizedUrl, displayName, importId: '' });
+      setImportedProfile({ url: normalizedUrl, displayName });
       setState('success');
-      onImport?.(normalizedUrl, '');
+      onImport?.(normalizedUrl);
     }
   };
 

--- a/src/components/pages/onboarding/LinkedInImport/types.ts
+++ b/src/components/pages/onboarding/LinkedInImport/types.ts
@@ -3,12 +3,14 @@
  */
 
 export interface LinkedInImportProps {
-  onImport?: (url: string) => void;
+  onImport?: (url: string, importId: string) => void;
   onRemove?: () => void;
+  importFn?: (url: string) => Promise<{ importId: string }>;
   className?: string;
 }
 
 export interface ImportedProfile {
   url: string;
   displayName: string;
+  importId: string;
 }

--- a/src/components/pages/onboarding/LinkedInImport/types.ts
+++ b/src/components/pages/onboarding/LinkedInImport/types.ts
@@ -3,7 +3,7 @@
  */
 
 export interface LinkedInImportProps {
-  onImport?: (url: string, importId: string) => void;
+  onImport?: (url: string, importId?: string) => void;
   onRemove?: () => void;
   importFn?: (url: string) => Promise<{ importId: string }>;
   className?: string;
@@ -12,5 +12,5 @@ export interface LinkedInImportProps {
 export interface ImportedProfile {
   url: string;
   displayName: string;
-  importId: string;
+  importId?: string;
 }

--- a/src/modules/cv/data/actions.ts
+++ b/src/modules/cv/data/actions.ts
@@ -12,6 +12,7 @@ import {
   createCv,
   deleteCv,
   duplicateCv,
+  importLinkedInProfile,
   importLinkedInToCv,
   exportCvPdf,
   updateCertifications,
@@ -259,7 +260,21 @@ export async function updateSectionAction<T extends SectionName>(
   }
 }
 
-// ─── Import action ────────────────────────────────────────────────────────────
+// ─── Import actions ───────────────────────────────────────────────────────────
+
+export async function importLinkedInProfileAction(
+  handleOrUrl: string
+): Promise<ActionResult<{ importId: string }>> {
+  try {
+    const result = await importLinkedInProfile(handleOrUrl);
+    return { ok: true, data: result };
+  } catch (error) {
+    return toFailureResult(
+      error,
+      'Unable to import your LinkedIn profile. Make sure your LinkedIn account is connected.'
+    );
+  }
+}
 
 export async function importLinkedInToCvAction(input: {
   importId: string;

--- a/src/modules/cv/data/contracts.ts
+++ b/src/modules/cv/data/contracts.ts
@@ -172,6 +172,31 @@ export interface ImportLinkedInToCvRequest {
   templateId?: string;
 }
 
+export interface ImportLinkedInProfileRequest {
+  handleOrUrl: string;
+}
+
+export interface LinkedInImportSourceContract {
+  provider: string;
+  importId?: string;
+  handle?: string | null;
+  url?: string | null;
+  fetchedAt: string;
+  dataScope: string[];
+  warnings?: string[];
+}
+
+export interface LinkedInImportProfileContract {
+  fullName?: string | null;
+  headline?: string | null;
+  email?: string | null;
+}
+
+export interface LinkedInImportResponseContract {
+  source: LinkedInImportSourceContract;
+  profile: LinkedInImportProfileContract;
+}
+
 export interface UpsertPersonalInfoRequest {
   fullName?: string;
   email?: string;

--- a/src/modules/cv/data/mutations.ts
+++ b/src/modules/cv/data/mutations.ts
@@ -234,7 +234,7 @@ export async function importLinkedInProfile(
     if (!importId) {
       throw new HttpError(
         500,
-        'Server Error',
+        'Something went wrong. Please try again.',
         'Import ID missing from response'
       );
     }

--- a/src/modules/cv/data/mutations.ts
+++ b/src/modules/cv/data/mutations.ts
@@ -28,9 +28,11 @@ import type {
   EducationResponseContract,
   ExperienceItemRequest,
   ExperienceResponseContract,
+  ImportLinkedInProfileRequest,
   ImportLinkedInToCvRequest,
   LanguageItemRequest,
   LanguageResponseContract,
+  LinkedInImportResponseContract,
   PersonalInfoResponseContract,
   ProjectItemRequest,
   ProjectResponseContract,
@@ -218,6 +220,27 @@ export async function updateCustomSections(
 }
 
 // ─── Import / Export ──────────────────────────────────────────────────────────
+
+export async function importLinkedInProfile(
+  handleOrUrl: string
+): Promise<{ importId: string }> {
+  return executeAuthenticatedRequest(async (headers) => {
+    const contract = await apiClient.post<
+      LinkedInImportResponseContract,
+      ImportLinkedInProfileRequest
+    >('oauth/linkedin/import', { handleOrUrl }, { headers });
+
+    const importId = contract.source.importId;
+    if (!importId) {
+      throw new HttpError(
+        500,
+        'Server Error',
+        'Import ID missing from response'
+      );
+    }
+    return { importId };
+  });
+}
 
 export async function importLinkedInToCv(
   body: ImportLinkedInToCvRequest


### PR DESCRIPTION
## Summary

Fixes onboarding flow pages to use real API calls instead of simulated/fake progress.

### Changes

- **Fixed skip buttons** on upload-cv and import-linkedin pages (proper routing)
- **Replaced fake progress simulation** with real LinkedIn import API call
- **Added `importLinkedInProfile` mutation + server action** for the LinkedIn import step
- **Wired `importId` through select-template** to create pre-populated CVs from imported data

### Flow
1. User starts onboarding → upload CV or import LinkedIn
2. LinkedIn import now calls the real backend API and tracks progress
3. Import ID is passed through to template selection
4. Template selection creates a CV pre-populated with imported data