### PR TITLE
design: replace hardcoded grays with design tokens on landing page

### DIFF
--- a/src/components/pages/landing-page/FAQ.tsx
+++ b/src/components/pages/landing-page/FAQ.tsx
@@ -71,6 +71,8 @@ export const FAQ = () => {
                 className='border border-border-subtle rounded-lg overflow-hidden transition-all duration-300 hover:shadow-md'
               >
                 <button
+                  id={`faq-btn-${index}`}
+                  type='button'
                   onClick={() => toggleFAQ(index)}
                   aria-expanded={openIndex === index}
                   aria-controls={`faq-answer-${index}`}
@@ -104,6 +106,7 @@ export const FAQ = () => {
                 <div
                   id={`faq-answer-${index}`}
                   role='region'
+                  aria-labelledby={`faq-btn-${index}`}
                   aria-hidden={openIndex !== index}
                   className={`grid transition-all duration-300 ease-in-out ${
                     openIndex === index

--- a/src/components/pages/landing-page/FAQ.tsx
+++ b/src/components/pages/landing-page/FAQ.tsx
@@ -72,6 +72,8 @@ export const FAQ = () => {
               >
                 <button
                   onClick={() => toggleFAQ(index)}
+                  aria-expanded={openIndex === index}
+                  aria-controls={`faq-answer-${index}`}
                   className='w-full px-6 py-4 flex items-center justify-between text-left bg-surface-card hover:bg-surface-page transition-colors cursor-pointer'
                 >
                   <span className='text-base md:text-lg font-medium pr-4'>
@@ -100,6 +102,9 @@ export const FAQ = () => {
                   </div>
                 </button>
                 <div
+                  id={`faq-answer-${index}`}
+                  role='region'
+                  aria-hidden={openIndex !== index}
                   className={`grid transition-all duration-300 ease-in-out ${
                     openIndex === index
                       ? 'grid-rows-[1fr] opacity-100'

--- a/src/components/pages/landing-page/FAQ.tsx
+++ b/src/components/pages/landing-page/FAQ.tsx
@@ -55,7 +55,7 @@ export const FAQ = () => {
   };
 
   return (
-    <section className='py-16 md:py-20 bg-white' id='faq'>
+    <section className='py-16 md:py-20 bg-background' id='faq'>
       <div className='container mx-auto px-4'>
         {/* Section Title */}
         <h2 className='text-3xl md:text-4xl lg:text-5xl font-semibold text-center mb-12 md:mb-16'>
@@ -68,11 +68,11 @@ export const FAQ = () => {
             {faqData.map((faq, index) => (
               <div
                 key={faq.question}
-                className='border border-gray-200 rounded-lg overflow-hidden transition-all duration-300 hover:shadow-md'
+                className='border border-border-subtle rounded-lg overflow-hidden transition-all duration-300 hover:shadow-md'
               >
                 <button
                   onClick={() => toggleFAQ(index)}
-                  className='w-full px-6 py-4 flex items-center justify-between text-left bg-white hover:bg-gray-50 transition-colors cursor-pointer'
+                  className='w-full px-6 py-4 flex items-center justify-between text-left bg-surface-card hover:bg-surface-page transition-colors cursor-pointer'
                 >
                   <span className='text-base md:text-lg font-medium pr-4'>
                     {faq.question}
@@ -107,7 +107,7 @@ export const FAQ = () => {
                   }`}
                 >
                   <div className='overflow-hidden'>
-                    <div className='px-6 py-4 bg-gray-50 border-t border-gray-200'>
+                    <div className='px-6 py-4 bg-surface-page border-t border-border-subtle'>
                       <p className='text-muted-foreground leading-relaxed'>
                         {faq.answer}
                       </p>

--- a/src/components/pages/landing-page/JobTracking.tsx
+++ b/src/components/pages/landing-page/JobTracking.tsx
@@ -164,8 +164,8 @@ export const JobTracking = () => {
               </div>
 
               {/* Description Card - Overlapping the header */}
-              <div className='relative -mt-18 bg-white rounded-xl shadow-lg px-4 py-6 min-h-32'>
-                <p className='text-sm text-gray-900 leading-relaxed'>
+              <div className='relative -mt-18 bg-surface-card rounded-xl shadow-lg px-4 py-6 min-h-32'>
+                <p className='text-sm text-content-primary leading-relaxed'>
                   {card.description}
                 </p>
               </div>

--- a/src/components/pages/landing-page/LearningRoadmap.tsx
+++ b/src/components/pages/landing-page/LearningRoadmap.tsx
@@ -92,7 +92,7 @@ const roadmapSteps = [
 
 export const LearningRoadmap = () => {
   return (
-    <section className='py-16 md:py-20 bg-gray-50'>
+    <section className='py-16 md:py-20 bg-surface-page'>
       <div className='container mx-auto px-4'>
         {/* Section Title */}
         <div className='text-center mb-12 md:mb-16 max-w-4xl mx-auto'>
@@ -110,7 +110,7 @@ export const LearningRoadmap = () => {
           {roadmapSteps.map((step) => (
             <div
               key={step.id}
-              className='bg-white rounded-2xl p-8 shadow-md hover:shadow-xl transition-all duration-300 border border-gray-100'
+              className='bg-surface-card rounded-2xl p-8 shadow-md hover:shadow-xl transition-all duration-300 border border-border-subtle'
             >
               {/* Icon */}
               <div className='mb-6'>
@@ -120,7 +120,7 @@ export const LearningRoadmap = () => {
               </div>
 
               {/* Title */}
-              <h3 className='text-xl font-semibold mb-3 text-gray-900'>
+              <h3 className='text-xl font-semibold mb-3 text-content-primary'>
                 {step.title}
               </h3>
 

--- a/src/components/pages/landing-page/Pricing.tsx
+++ b/src/components/pages/landing-page/Pricing.tsx
@@ -162,19 +162,19 @@ export const Pricing = () => {
               key={tier.name}
               className={`rounded-2xl p-8 transition-all duration-300 ${
                 tier.featured
-                  ? 'bg-primary text-white scale-105 shadow-2xl'
+                  ? 'bg-primary text-content-inverse scale-105 shadow-2xl'
                   : 'bg-surface-card border-2 border-primary/20 shadow-lg hover:shadow-xl'
               }`}
             >
               {/* Card Header */}
               <div className='mb-6'>
                 <h3
-                  className={`text-2xl font-semibold mb-2 ${tier.featured ? 'text-white' : 'text-content-primary'}`}
+                  className={`text-2xl font-semibold mb-2 ${tier.featured ? 'text-content-inverse' : 'text-content-primary'}`}
                 >
                   {tier.name}
                 </h3>
                 <p
-                  className={`text-sm ${tier.featured ? 'text-white/80' : 'text-muted-foreground'}`}
+                  className={`text-sm ${tier.featured ? 'text-content-inverse/80' : 'text-muted-foreground'}`}
                 >
                   {tier.description}
                 </p>
@@ -184,12 +184,12 @@ export const Pricing = () => {
               <div className='mb-6'>
                 <div className='flex items-baseline gap-2'>
                   <span
-                    className={`text-5xl font-bold ${tier.featured ? 'text-white' : 'text-content-primary'}`}
+                    className={`text-5xl font-bold ${tier.featured ? 'text-content-inverse' : 'text-content-primary'}`}
                   >
                     ${isYearly ? tier.yearlyPrice : tier.monthlyPrice}
                   </span>
                   <span
-                    className={`text-lg ${tier.featured ? 'text-white/70' : 'text-muted-foreground'}`}
+                    className={`text-lg ${tier.featured ? 'text-content-inverse/70' : 'text-muted-foreground'}`}
                   >
                     / Month
                   </span>
@@ -214,7 +214,7 @@ export const Pricing = () => {
                   <li key={index} className='flex items-start gap-3'>
                     <CheckIcon featured={tier.featured} />
                     <span
-                      className={`text-sm ${tier.featured ? 'text-white' : 'text-content-secondary'}`}
+                      className={`text-sm ${tier.featured ? 'text-content-inverse' : 'text-content-secondary'}`}
                     >
                       {feature}
                     </span>

--- a/src/components/pages/landing-page/Pricing.tsx
+++ b/src/components/pages/landing-page/Pricing.tsx
@@ -111,9 +111,14 @@ export const Pricing = () => {
 
           {/* Toggle Switch */}
           <div className='flex items-center justify-center relative'>
-            <div className='inline-flex items-center bg-surface-page rounded-full p-1'>
+            <div
+              className='inline-flex items-center bg-surface-page rounded-full p-1'
+              role='group'
+              aria-label='Billing period'
+            >
               <button
                 onClick={() => setIsYearly(false)}
+                aria-pressed={!isYearly}
                 className={`px-6 py-2 rounded-full text-sm font-medium transition-all ${
                   !isYearly
                     ? 'bg-surface-card text-content-primary shadow-sm'
@@ -124,9 +129,10 @@ export const Pricing = () => {
               </button>
               <button
                 onClick={() => setIsYearly(true)}
+                aria-pressed={isYearly}
                 className={`px-6 py-2 rounded-full text-sm font-medium transition-all ${
                   isYearly
-                    ? 'bg-primary text-white shadow-sm'
+                    ? 'bg-primary text-content-inverse shadow-sm'
                     : 'bg-transparent text-content-secondary'
                 }`}
               >
@@ -194,8 +200,8 @@ export const Pricing = () => {
               <Button
                 className={`w-full mb-8 py-6 rounded-lg text-base font-medium transition-all ${
                   tier.featured
-                    ? 'bg-white text-primary hover:bg-surface-page'
-                    : 'bg-transparent border-2 border-primary text-primary hover:bg-primary hover:text-white'
+                    ? 'bg-surface-card text-primary hover:bg-surface-page'
+                    : 'bg-transparent border-2 border-primary text-primary hover:bg-primary hover:text-content-inverse'
                 }`}
                 asChild
               >

--- a/src/components/pages/landing-page/Pricing.tsx
+++ b/src/components/pages/landing-page/Pricing.tsx
@@ -94,7 +94,7 @@ export const Pricing = () => {
 
   return (
     <section
-      className='py-16 md:py-20 bg-linear-to-b from-white to-gray-50'
+      className='py-16 md:py-20 bg-linear-to-b from-background to-surface-page'
       id='pricing'
     >
       <div className='container mx-auto px-4'>
@@ -111,13 +111,13 @@ export const Pricing = () => {
 
           {/* Toggle Switch */}
           <div className='flex items-center justify-center relative'>
-            <div className='inline-flex items-center bg-gray-100 rounded-full p-1'>
+            <div className='inline-flex items-center bg-surface-page rounded-full p-1'>
               <button
                 onClick={() => setIsYearly(false)}
                 className={`px-6 py-2 rounded-full text-sm font-medium transition-all ${
                   !isYearly
-                    ? 'bg-white text-gray-900 shadow-sm'
-                    : 'bg-transparent text-gray-600'
+                    ? 'bg-surface-card text-content-primary shadow-sm'
+                    : 'bg-transparent text-content-secondary'
                 }`}
               >
                 Monthly
@@ -127,7 +127,7 @@ export const Pricing = () => {
                 className={`px-6 py-2 rounded-full text-sm font-medium transition-all ${
                   isYearly
                     ? 'bg-primary text-white shadow-sm'
-                    : 'bg-transparent text-gray-600'
+                    : 'bg-transparent text-content-secondary'
                 }`}
               >
                 Yearly
@@ -157,13 +157,13 @@ export const Pricing = () => {
               className={`rounded-2xl p-8 transition-all duration-300 ${
                 tier.featured
                   ? 'bg-primary text-white scale-105 shadow-2xl'
-                  : 'bg-white border-2 border-primary/20 shadow-lg hover:shadow-xl'
+                  : 'bg-surface-card border-2 border-primary/20 shadow-lg hover:shadow-xl'
               }`}
             >
               {/* Card Header */}
               <div className='mb-6'>
                 <h3
-                  className={`text-2xl font-semibold mb-2 ${tier.featured ? 'text-white' : 'text-gray-900'}`}
+                  className={`text-2xl font-semibold mb-2 ${tier.featured ? 'text-white' : 'text-content-primary'}`}
                 >
                   {tier.name}
                 </h3>
@@ -178,7 +178,7 @@ export const Pricing = () => {
               <div className='mb-6'>
                 <div className='flex items-baseline gap-2'>
                   <span
-                    className={`text-5xl font-bold ${tier.featured ? 'text-white' : 'text-gray-900'}`}
+                    className={`text-5xl font-bold ${tier.featured ? 'text-white' : 'text-content-primary'}`}
                   >
                     ${isYearly ? tier.yearlyPrice : tier.monthlyPrice}
                   </span>
@@ -194,7 +194,7 @@ export const Pricing = () => {
               <Button
                 className={`w-full mb-8 py-6 rounded-lg text-base font-medium transition-all ${
                   tier.featured
-                    ? 'bg-white text-primary hover:bg-gray-100'
+                    ? 'bg-white text-primary hover:bg-surface-page'
                     : 'bg-transparent border-2 border-primary text-primary hover:bg-primary hover:text-white'
                 }`}
                 asChild
@@ -208,7 +208,7 @@ export const Pricing = () => {
                   <li key={index} className='flex items-start gap-3'>
                     <CheckIcon featured={tier.featured} />
                     <span
-                      className={`text-sm ${tier.featured ? 'text-white' : 'text-gray-700'}`}
+                      className={`text-sm ${tier.featured ? 'text-white' : 'text-content-secondary'}`}
                     >
                       {feature}
                     </span>

--- a/src/components/pages/landing-page/TemplatePicker.tsx
+++ b/src/components/pages/landing-page/TemplatePicker.tsx
@@ -44,7 +44,7 @@ export const TemplatePicker = () => {
     >
       <div className='container mx-auto px-4'>
         {/* Section Title */}
-        <h2 className='text-3xl md:text-4xl lg:text-5xl font-semibold text-center mb-8 text-gray-900'>
+        <h2 className='text-3xl md:text-4xl lg:text-5xl font-semibold text-center mb-8 text-content-primary'>
           Pick the Perfect Resume Template
         </h2>
 
@@ -100,7 +100,7 @@ export const TemplatePicker = () => {
                   'w-4 h-4 rounded-full cursor-pointer transition-all duration-300',
                   current === index
                     ? 'bg-primary'
-                    : 'bg-gray-300 hover:bg-gray-400'
+                    : 'bg-border hover:bg-border-strong'
                 )}
                 aria-label={`Go to slide ${index + 1}`}
               />

--- a/src/components/pages/landing-page/TemplatePicker.tsx
+++ b/src/components/pages/landing-page/TemplatePicker.tsx
@@ -97,13 +97,20 @@ export const TemplatePicker = () => {
                 key={index}
                 onClick={() => api?.scrollTo(index)}
                 className={cn(
-                  'w-4 h-4 rounded-full cursor-pointer transition-all duration-300',
-                  current === index
-                    ? 'bg-primary'
-                    : 'bg-border hover:bg-border-strong'
+                  'min-w-[44px] min-h-[44px] flex items-center justify-center cursor-pointer'
                 )}
                 aria-label={`Go to slide ${index + 1}`}
-              />
+                aria-current={current === index ? 'true' : undefined}
+              >
+                <span
+                  className={cn(
+                    'w-3 h-3 rounded-full transition-all duration-300',
+                    current === index
+                      ? 'bg-primary scale-125'
+                      : 'bg-border hover:bg-border-strong'
+                  )}
+                />
+              </button>
             ))}
           </div>
 

--- a/src/components/pages/landing-page/TemplatePicker.tsx
+++ b/src/components/pages/landing-page/TemplatePicker.tsx
@@ -95,9 +95,10 @@ export const TemplatePicker = () => {
             {templateImages.map((_, index) => (
               <button
                 key={index}
+                type='button'
                 onClick={() => api?.scrollTo(index)}
                 className={cn(
-                  'min-w-[44px] min-h-[44px] flex items-center justify-center cursor-pointer'
+                  'group min-w-[44px] min-h-[44px] flex items-center justify-center cursor-pointer'
                 )}
                 aria-label={`Go to slide ${index + 1}`}
                 aria-current={current === index ? 'true' : undefined}
@@ -107,7 +108,7 @@ export const TemplatePicker = () => {
                     'w-3 h-3 rounded-full transition-all duration-300',
                     current === index
                       ? 'bg-primary scale-125'
-                      : 'bg-border hover:bg-border-strong'
+                      : 'bg-border group-hover:bg-border-strong'
                   )}
                 />
               </button>


### PR DESCRIPTION
Replaces ~30 hardcoded gray/white Tailwind classes with semantic design tokens (content-primary, surface-card, border-subtle, etc.) across landing page components. Status colors and SVG fills are intentionally left for a follow-up.