### PR TITLE
feat: add loading skeletons for all protected routes

### DIFF
--- a/src/app/(site)/cv/[id]/edit/loading.tsx
+++ b/src/app/(site)/cv/[id]/edit/loading.tsx
@@ -1,0 +1,28 @@
+export default function CvEditLoading() {
+  return (
+    <div className='flex h-[calc(100vh-4rem)] animate-pulse'>
+      {/* Sidebar */}
+      <div className='w-64 border-r border-border p-4 space-y-4'>
+        <div className='h-6 w-32 bg-border rounded' />
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className='h-10 w-full bg-border rounded' />
+        ))}
+      </div>
+
+      {/* Main editor area */}
+      <div className='flex-1 p-6 space-y-6'>
+        <div className='h-8 w-64 bg-border rounded' />
+        <div className='space-y-3'>
+          <div className='h-4 w-full bg-border rounded' />
+          <div className='h-4 w-5/6 bg-border rounded' />
+          <div className='h-4 w-4/6 bg-border rounded' />
+        </div>
+        <div className='h-40 w-full bg-border rounded-lg' />
+        <div className='space-y-3'>
+          <div className='h-4 w-full bg-border rounded' />
+          <div className='h-4 w-3/4 bg-border rounded' />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/cv/[id]/edit/loading.tsx
+++ b/src/app/(site)/cv/[id]/edit/loading.tsx
@@ -1,26 +1,38 @@
 export default function CvEditLoading() {
   return (
-    <div className='flex h-[calc(100vh-4rem)] animate-pulse'>
-      {/* Sidebar */}
-      <div className='w-64 border-r border-border p-4 space-y-4'>
-        <div className='h-6 w-32 bg-border rounded' />
-        {[1, 2, 3, 4, 5].map((i) => (
-          <div key={i} className='h-10 w-full bg-border rounded' />
-        ))}
+    <div className='min-h-screen bg-surface-primary animate-pulse'>
+      {/* Editor header */}
+      <div className='sticky top-0 z-10 border-b border-subtle bg-surface-primary px-4 py-3'>
+        <div className='mx-auto flex max-w-7xl items-center justify-between'>
+          <div className='h-6 w-48 rounded bg-surface-elevated' />
+          <div className='flex gap-2'>
+            <div className='h-9 w-20 rounded bg-surface-elevated' />
+            <div className='h-9 w-24 rounded bg-surface-elevated' />
+          </div>
+        </div>
       </div>
 
-      {/* Main editor area */}
-      <div className='flex-1 p-6 space-y-6'>
-        <div className='h-8 w-64 bg-border rounded' />
-        <div className='space-y-3'>
-          <div className='h-4 w-full bg-border rounded' />
-          <div className='h-4 w-5/6 bg-border rounded' />
-          <div className='h-4 w-4/6 bg-border rounded' />
-        </div>
-        <div className='h-40 w-full bg-border rounded-lg' />
-        <div className='space-y-3'>
-          <div className='h-4 w-full bg-border rounded' />
-          <div className='h-4 w-3/4 bg-border rounded' />
+      {/* Main content: grid matching editor layout */}
+      <div className='mx-auto max-w-7xl px-4 py-6'>
+        <div className='grid grid-cols-1 gap-6 lg:grid-cols-3'>
+          {/* Left panel — form sections */}
+          <div className='space-y-4 lg:col-span-2'>
+            {[1, 2, 3].map((i) => (
+              <div
+                key={i}
+                className='rounded-lg border border-subtle bg-surface-card p-4 space-y-3'
+              >
+                <div className='h-5 w-32 rounded bg-surface-elevated' />
+                <div className='h-10 w-full rounded bg-surface-elevated' />
+                <div className='h-10 w-full rounded bg-surface-elevated' />
+              </div>
+            ))}
+          </div>
+
+          {/* Right panel — preview */}
+          <div className='lg:col-span-1'>
+            <div className='sticky top-20 h-[600px] rounded-lg border border-subtle bg-surface-elevated' />
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(site)/dashboard/loading.tsx
+++ b/src/app/(site)/dashboard/loading.tsx
@@ -1,0 +1,21 @@
+export default function DashboardLoading() {
+  return (
+    <div className='container mx-auto px-4 py-8 animate-pulse'>
+      {/* Title skeleton */}
+      <div className='h-8 w-48 bg-border rounded mb-6' />
+
+      {/* Stats cards grid */}
+      <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8'>
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className='h-32 rounded-lg bg-border' />
+        ))}
+      </div>
+
+      {/* Main content area */}
+      <div className='grid grid-cols-1 lg:grid-cols-3 gap-6'>
+        <div className='lg:col-span-2 h-64 rounded-lg bg-border' />
+        <div className='h-64 rounded-lg bg-border' />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/dashboard/loading.tsx
+++ b/src/app/(site)/dashboard/loading.tsx
@@ -2,19 +2,19 @@ export default function DashboardLoading() {
   return (
     <div className='container mx-auto px-4 py-8 animate-pulse'>
       {/* Title skeleton */}
-      <div className='h-8 w-48 bg-border rounded mb-6' />
+      <div className='h-8 w-48 bg-surface-elevated rounded mb-6' />
 
       {/* Stats cards grid */}
       <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8'>
         {[1, 2, 3, 4].map((i) => (
-          <div key={i} className='h-32 rounded-lg bg-border' />
+          <div key={i} className='h-32 rounded-lg bg-surface-elevated' />
         ))}
       </div>
 
       {/* Main content area */}
       <div className='grid grid-cols-1 lg:grid-cols-3 gap-6'>
-        <div className='lg:col-span-2 h-64 rounded-lg bg-border' />
-        <div className='h-64 rounded-lg bg-border' />
+        <div className='lg:col-span-2 h-64 rounded-lg bg-surface-elevated' />
+        <div className='h-64 rounded-lg bg-surface-elevated' />
       </div>
     </div>
   );

--- a/src/app/(site)/interview/loading.tsx
+++ b/src/app/(site)/interview/loading.tsx
@@ -1,0 +1,23 @@
+export default function InterviewLoading() {
+  return (
+    <div className='container mx-auto px-4 py-8 animate-pulse'>
+      {/* Title skeleton */}
+      <div className='h-8 w-52 bg-border rounded mb-6' />
+
+      {/* Filter bar */}
+      <div className='flex flex-wrap gap-3 mb-8'>
+        <div className='h-10 w-36 bg-border rounded' />
+        <div className='h-10 w-36 bg-border rounded' />
+        <div className='h-10 w-36 bg-border rounded' />
+        <div className='ml-auto h-10 w-28 bg-border rounded' />
+      </div>
+
+      {/* Question cards */}
+      <div className='space-y-4'>
+        {[1, 2, 3, 4, 5].map((i) => (
+          <div key={i} className='h-24 rounded-lg bg-border' />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/interview/loading.tsx
+++ b/src/app/(site)/interview/loading.tsx
@@ -2,20 +2,20 @@ export default function InterviewLoading() {
   return (
     <div className='container mx-auto px-4 py-8 animate-pulse'>
       {/* Title skeleton */}
-      <div className='h-8 w-52 bg-border rounded mb-6' />
+      <div className='h-8 w-52 bg-surface-elevated rounded mb-6' />
 
       {/* Filter bar */}
       <div className='flex flex-wrap gap-3 mb-8'>
-        <div className='h-10 w-36 bg-border rounded' />
-        <div className='h-10 w-36 bg-border rounded' />
-        <div className='h-10 w-36 bg-border rounded' />
-        <div className='ml-auto h-10 w-28 bg-border rounded' />
+        <div className='h-10 w-36 bg-surface-elevated rounded' />
+        <div className='h-10 w-36 bg-surface-elevated rounded' />
+        <div className='h-10 w-36 bg-surface-elevated rounded' />
+        <div className='ml-auto h-10 w-28 bg-surface-elevated rounded' />
       </div>
 
       {/* Question cards */}
       <div className='space-y-4'>
         {[1, 2, 3, 4, 5].map((i) => (
-          <div key={i} className='h-24 rounded-lg bg-border' />
+          <div key={i} className='h-24 rounded-lg bg-surface-elevated' />
         ))}
       </div>
     </div>

--- a/src/app/(site)/jobs/loading.tsx
+++ b/src/app/(site)/jobs/loading.tsx
@@ -1,0 +1,34 @@
+export default function JobsLoading() {
+  return (
+    <div className='container mx-auto px-4 py-8 animate-pulse'>
+      {/* Title skeleton */}
+      <div className='h-8 w-40 bg-border rounded mb-6' />
+
+      {/* Stats row */}
+      <div className='grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8'>
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className='h-20 rounded-lg bg-border' />
+        ))}
+      </div>
+
+      {/* Toolbar */}
+      <div className='flex gap-3 mb-6'>
+        <div className='h-10 w-32 bg-border rounded' />
+        <div className='h-10 w-32 bg-border rounded' />
+        <div className='ml-auto h-10 w-28 bg-border rounded' />
+      </div>
+
+      {/* Kanban columns */}
+      <div className='grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4'>
+        {[1, 2, 3, 4, 5].map((col) => (
+          <div key={col} className='space-y-3'>
+            <div className='h-6 w-24 bg-border rounded' />
+            {[1, 2].map((card) => (
+              <div key={card} className='h-28 rounded-lg bg-border' />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/jobs/loading.tsx
+++ b/src/app/(site)/jobs/loading.tsx
@@ -2,29 +2,29 @@ export default function JobsLoading() {
   return (
     <div className='container mx-auto px-4 py-8 animate-pulse'>
       {/* Title skeleton */}
-      <div className='h-8 w-40 bg-border rounded mb-6' />
+      <div className='h-8 w-40 bg-surface-elevated rounded mb-6' />
 
       {/* Stats row */}
       <div className='grid grid-cols-2 sm:grid-cols-4 gap-4 mb-8'>
         {[1, 2, 3, 4].map((i) => (
-          <div key={i} className='h-20 rounded-lg bg-border' />
+          <div key={i} className='h-20 rounded-lg bg-surface-elevated' />
         ))}
       </div>
 
       {/* Toolbar */}
       <div className='flex gap-3 mb-6'>
-        <div className='h-10 w-32 bg-border rounded' />
-        <div className='h-10 w-32 bg-border rounded' />
-        <div className='ml-auto h-10 w-28 bg-border rounded' />
+        <div className='h-10 w-32 bg-surface-elevated rounded' />
+        <div className='h-10 w-32 bg-surface-elevated rounded' />
+        <div className='ml-auto h-10 w-28 bg-surface-elevated rounded' />
       </div>
 
       {/* Kanban columns */}
       <div className='grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4'>
         {[1, 2, 3, 4, 5].map((col) => (
           <div key={col} className='space-y-3'>
-            <div className='h-6 w-24 bg-border rounded' />
+            <div className='h-6 w-24 bg-surface-elevated rounded' />
             {[1, 2].map((card) => (
-              <div key={card} className='h-28 rounded-lg bg-border' />
+              <div key={card} className='h-28 rounded-lg bg-surface-elevated' />
             ))}
           </div>
         ))}

--- a/src/app/(site)/settings/loading.tsx
+++ b/src/app/(site)/settings/loading.tsx
@@ -2,21 +2,21 @@ export default function SettingsLoading() {
   return (
     <div className='container mx-auto px-4 py-8 animate-pulse max-w-2xl'>
       {/* Title skeleton */}
-      <div className='h-8 w-36 bg-border rounded mb-8' />
+      <div className='h-8 w-36 bg-surface-elevated rounded mb-8' />
 
       {/* Form sections */}
       {[1, 2, 3].map((section) => (
         <div key={section} className='mb-8'>
-          <div className='h-6 w-40 bg-border rounded mb-4' />
+          <div className='h-6 w-40 bg-surface-elevated rounded mb-4' />
           <div className='space-y-4'>
-            <div className='h-10 w-full bg-border rounded' />
-            <div className='h-10 w-full bg-border rounded' />
+            <div className='h-10 w-full bg-surface-elevated rounded' />
+            <div className='h-10 w-full bg-surface-elevated rounded' />
           </div>
         </div>
       ))}
 
       {/* Save button */}
-      <div className='h-10 w-24 bg-border rounded' />
+      <div className='h-10 w-24 bg-surface-elevated rounded' />
     </div>
   );
 }

--- a/src/app/(site)/settings/loading.tsx
+++ b/src/app/(site)/settings/loading.tsx
@@ -1,0 +1,22 @@
+export default function SettingsLoading() {
+  return (
+    <div className='container mx-auto px-4 py-8 animate-pulse max-w-2xl'>
+      {/* Title skeleton */}
+      <div className='h-8 w-36 bg-border rounded mb-8' />
+
+      {/* Form sections */}
+      {[1, 2, 3].map((section) => (
+        <div key={section} className='mb-8'>
+          <div className='h-6 w-40 bg-border rounded mb-4' />
+          <div className='space-y-4'>
+            <div className='h-10 w-full bg-border rounded' />
+            <div className='h-10 w-full bg-border rounded' />
+          </div>
+        </div>
+      ))}
+
+      {/* Save button */}
+      <div className='h-10 w-24 bg-border rounded' />
+    </div>
+  );
+}

--- a/src/app/(site)/skills/loading.tsx
+++ b/src/app/(site)/skills/loading.tsx
@@ -1,0 +1,16 @@
+export default function SkillsLoading() {
+  return (
+    <div className='container mx-auto px-4 py-8 animate-pulse'>
+      {/* Title skeleton */}
+      <div className='h-8 w-56 bg-border rounded mb-2' />
+      <div className='h-4 w-80 bg-border rounded mb-8' />
+
+      {/* Category cards grid */}
+      <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6'>
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className='h-40 rounded-lg bg-border' />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(site)/skills/loading.tsx
+++ b/src/app/(site)/skills/loading.tsx
@@ -2,13 +2,13 @@ export default function SkillsLoading() {
   return (
     <div className='container mx-auto px-4 py-8 animate-pulse'>
       {/* Title skeleton */}
-      <div className='h-8 w-56 bg-border rounded mb-2' />
-      <div className='h-4 w-80 bg-border rounded mb-8' />
+      <div className='h-8 w-56 bg-surface-elevated rounded mb-2' />
+      <div className='h-4 w-80 bg-surface-elevated rounded mb-8' />
 
       {/* Category cards grid */}
       <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6'>
         {[1, 2, 3, 4, 5, 6].map((i) => (
-          <div key={i} className='h-40 rounded-lg bg-border' />
+          <div key={i} className='h-40 rounded-lg bg-surface-elevated' />
         ))}
       </div>
     </div>


### PR DESCRIPTION
Adds Next.js loading.tsx skeleton screens for dashboard, jobs, skills, interview, CV editor, and settings pages. Uses semantic design tokens (bg-border for skeleton elements) with animate-pulse for smooth loading states.