### PR TITLE
test: backfill co-located data-layer tests for ai/jobs/skills/intervi…

### DIFF
--- a/src/modules/ai/data/actions.test.ts
+++ b/src/modules/ai/data/actions.test.ts
@@ -1,0 +1,131 @@
+import { HttpError } from '@/shared/http/http-error';
+import { analyzeCvAction, optimizeCvAction } from './actions';
+import type { CvAnalysisResult, CvOptimizationResult } from './mappers';
+
+jest.mock('./mutations', () => ({
+  analyzeCv: jest.fn(),
+  optimizeCvForJob: jest.fn(),
+}));
+
+const mutations = jest.requireMock('./mutations') as {
+  analyzeCv: jest.Mock;
+  optimizeCvForJob: jest.Mock;
+};
+
+const analysis: CvAnalysisResult = {
+  overallScore: 80,
+  grammarScore: 85,
+  readabilityScore: 75,
+  atsScore: 70,
+  issues: [],
+  suggestions: [],
+};
+
+const optimization: CvOptimizationResult = {
+  matchScore: 88,
+  missingKeywords: ['GraphQL'],
+  suggestions: [],
+  sectionRecommendations: [],
+};
+
+describe('ai actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('analyzeCvAction', () => {
+    it('returns the analysis result on success', async () => {
+      mutations.analyzeCv.mockResolvedValueOnce(analysis);
+
+      const result = await analyzeCvAction('cv_001');
+
+      expect(result).toEqual({ ok: true, data: analysis });
+      expect(mutations.analyzeCv).toHaveBeenCalledWith('cv_001');
+    });
+
+    it('maps a 404 HttpError to not_found with the server message', async () => {
+      mutations.analyzeCv.mockRejectedValueOnce(
+        new HttpError(404, 'Not Found', 'CV not found')
+      );
+
+      const result = await analyzeCvAction('cv_404');
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'not_found',
+        message: 'CV not found',
+      });
+    });
+
+    it('maps a 403 HttpError to forbidden', async () => {
+      mutations.analyzeCv.mockRejectedValueOnce(
+        new HttpError(403, 'Forbidden', 'Access denied')
+      );
+
+      const result = await analyzeCvAction('cv_001');
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'forbidden',
+        message: 'Access denied',
+      });
+    });
+
+    it('maps a 401 HttpError to unauthorized', async () => {
+      mutations.analyzeCv.mockRejectedValueOnce(
+        new HttpError(401, 'Unauthorized', 'Token expired')
+      );
+
+      const result = await analyzeCvAction('cv_001');
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unauthorized',
+        message: 'Token expired',
+      });
+    });
+
+    it('maps a generic error to unknown with the fallback message', async () => {
+      mutations.analyzeCv.mockRejectedValueOnce(new Error('Network failure'));
+
+      const result = await analyzeCvAction('cv_001');
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unknown',
+        message: 'Unable to analyze your CV.',
+      });
+    });
+  });
+
+  describe('optimizeCvAction', () => {
+    it('passes the job description through and returns the result', async () => {
+      mutations.optimizeCvForJob.mockResolvedValueOnce(optimization);
+
+      const result = await optimizeCvAction('cv_001', {
+        jobDescription: 'Senior backend engineer',
+      });
+
+      expect(result).toEqual({ ok: true, data: optimization });
+      expect(mutations.optimizeCvForJob).toHaveBeenCalledWith('cv_001', {
+        jobDescription: 'Senior backend engineer',
+      });
+    });
+
+    it('maps failures to the unknown fallback for optimization', async () => {
+      mutations.optimizeCvForJob.mockRejectedValueOnce(
+        new HttpError(500, 'Internal', 'Model timeout')
+      );
+
+      const result = await optimizeCvAction('cv_001', {
+        jobDescription: 'x',
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unknown',
+        message: 'Unable to optimize your CV.',
+      });
+    });
+  });
+});

--- a/src/modules/ai/data/mappers.test.ts
+++ b/src/modules/ai/data/mappers.test.ts
@@ -1,0 +1,138 @@
+import type {
+  CvAnalysisResultContract,
+  CvOptimizationResultContract,
+} from './contracts';
+import { toCvAnalysis, toCvOptimization } from './mappers';
+
+describe('toCvAnalysis', () => {
+  it('maps scores, issues, and suggestions into the domain shape', () => {
+    const contract = {
+      overallScore: 78,
+      grammarScore: 90,
+      readabilityScore: 70,
+      atsScore: 65,
+      issues: [
+        {
+          section: 'summary',
+          type: 'grammar',
+          severity: 'high',
+          message: 'Passive voice detected.',
+          suggestion: 'Use active voice.',
+        },
+      ],
+      suggestions: [
+        {
+          section: 'experience',
+          type: 'improvement',
+          message: 'Quantify achievements.',
+          originalText: 'Led a team',
+          suggestedText: 'Led a team of 6 engineers',
+        },
+      ],
+    } satisfies CvAnalysisResultContract;
+
+    const result = toCvAnalysis(contract);
+
+    expect(result.overallScore).toBe(78);
+    expect(result.grammarScore).toBe(90);
+    expect(result.readabilityScore).toBe(70);
+    expect(result.atsScore).toBe(65);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toEqual({
+      section: 'summary',
+      type: 'grammar',
+      severity: 'high',
+      message: 'Passive voice detected.',
+      suggestion: 'Use active voice.',
+    });
+    expect(result.suggestions[0].originalText).toBe('Led a team');
+    expect(result.suggestions[0].suggestedText).toBe(
+      'Led a team of 6 engineers'
+    );
+  });
+
+  it('coalesces missing optional issue and suggestion fields to null', () => {
+    const contract = {
+      overallScore: 50,
+      grammarScore: 50,
+      readabilityScore: 50,
+      atsScore: 50,
+      issues: [
+        {
+          section: 'skills',
+          type: 'ats',
+          severity: 'low',
+          message: 'Add more keywords.',
+        },
+      ],
+      suggestions: [
+        {
+          section: 'skills',
+          type: 'addition',
+          message: 'Add a cloud section.',
+        },
+      ],
+    } satisfies CvAnalysisResultContract;
+
+    const result = toCvAnalysis(contract);
+
+    expect(result.issues[0].suggestion).toBeNull();
+    expect(result.suggestions[0].originalText).toBeNull();
+    expect(result.suggestions[0].suggestedText).toBeNull();
+  });
+});
+
+describe('toCvOptimization', () => {
+  it('maps match score, keywords, suggestions, and recommendations', () => {
+    const contract = {
+      matchScore: 82,
+      missingKeywords: ['Kubernetes', 'Terraform'],
+      suggestions: [
+        {
+          section: 'summary',
+          type: 'improvement',
+          message: 'Mention cloud experience.',
+          originalText: 'Backend developer',
+          suggestedText: 'Cloud-native backend developer',
+        },
+      ],
+      sectionRecommendations: [
+        {
+          section: 'skills',
+          action: 'add',
+          message: 'Add a DevOps section.',
+          priority: 'high',
+        },
+      ],
+    } satisfies CvOptimizationResultContract;
+
+    const result = toCvOptimization(contract);
+
+    expect(result.matchScore).toBe(82);
+    expect(result.missingKeywords).toEqual(['Kubernetes', 'Terraform']);
+    expect(result.suggestions[0].suggestedText).toBe(
+      'Cloud-native backend developer'
+    );
+    expect(result.sectionRecommendations[0]).toEqual({
+      section: 'skills',
+      action: 'add',
+      message: 'Add a DevOps section.',
+      priority: 'high',
+    });
+  });
+
+  it('maps empty suggestion and recommendation collections to empty arrays', () => {
+    const contract = {
+      matchScore: 40,
+      missingKeywords: ['Go'],
+      suggestions: [],
+      sectionRecommendations: [],
+    } satisfies CvOptimizationResultContract;
+
+    const result = toCvOptimization(contract);
+
+    expect(result.missingKeywords).toEqual(['Go']);
+    expect(result.suggestions).toEqual([]);
+    expect(result.sectionRecommendations).toEqual([]);
+  });
+});

--- a/src/modules/billing/data/actions.test.ts
+++ b/src/modules/billing/data/actions.test.ts
@@ -1,0 +1,99 @@
+import { HttpError } from '@/shared/http/http-error';
+import {
+  createCheckoutSessionAction,
+  createPortalSessionAction,
+} from './actions';
+
+jest.mock('./mutations', () => ({
+  createCheckoutSession: jest.fn(),
+  createPortalSession: jest.fn(),
+}));
+
+const mutations = jest.requireMock('./mutations') as {
+  createCheckoutSession: jest.Mock;
+  createPortalSession: jest.Mock;
+};
+
+describe('billing actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createCheckoutSessionAction', () => {
+    it('returns the checkout session on success', async () => {
+      mutations.createCheckoutSession.mockResolvedValueOnce({
+        sessionId: 'cs_001',
+        url: 'https://checkout.example/cs_001',
+      });
+
+      const result = await createCheckoutSessionAction({
+        plan: 'PRO',
+        billingCycle: 'yearly',
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        data: { sessionId: 'cs_001', url: 'https://checkout.example/cs_001' },
+      });
+      expect(mutations.createCheckoutSession).toHaveBeenCalledWith({
+        plan: 'PRO',
+        billingCycle: 'yearly',
+      });
+    });
+
+    it('maps a 403 HttpError to forbidden', async () => {
+      mutations.createCheckoutSession.mockRejectedValueOnce(
+        new HttpError(403, 'Forbidden', 'Plan not available')
+      );
+
+      const result = await createCheckoutSessionAction({ plan: 'TEAM' });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'forbidden',
+        message: 'Plan not available',
+      });
+    });
+
+    it('maps a generic error to the unknown checkout fallback', async () => {
+      mutations.createCheckoutSession.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await createCheckoutSessionAction({ plan: 'PRO' });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unknown',
+        message: 'Unable to start checkout session. Please try again.',
+      });
+    });
+  });
+
+  describe('createPortalSessionAction', () => {
+    it('returns only the portal url on success', async () => {
+      mutations.createPortalSession.mockResolvedValueOnce({
+        url: 'https://portal.example/session',
+      });
+
+      const result = await createPortalSessionAction();
+
+      expect(result).toEqual({
+        ok: true,
+        data: { url: 'https://portal.example/session' },
+      });
+    });
+
+    it('maps a 401 HttpError to unauthorized', async () => {
+      mutations.createPortalSession.mockRejectedValueOnce(
+        new HttpError(401, 'Unauthorized', 'Session expired')
+      );
+
+      const result = await createPortalSessionAction();
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unauthorized',
+        message: 'Session expired',
+      });
+    });
+  });
+});

--- a/src/modules/billing/data/mappers.test.ts
+++ b/src/modules/billing/data/mappers.test.ts
@@ -1,0 +1,87 @@
+import type { BillingProfileContract } from './contracts';
+import { toBillingProfile } from './mappers';
+
+describe('toBillingProfile', () => {
+  it('maps a paid profile with an active subscription and quota dates', () => {
+    const contract = {
+      plan: 'PRO',
+      stripeCustomerId: 'cus_123',
+      subscription: {
+        id: 'sub_001',
+        status: 'active',
+        planCode: 'PRO',
+        currentPeriodStart: '2026-04-01T00:00:00.000Z',
+        currentPeriodEnd: '2026-05-01T00:00:00.000Z',
+        cancelAtPeriodEnd: false,
+      },
+      aiQuota: {
+        used: 12,
+        limit: 50,
+        remaining: 38,
+        periodEnd: '2026-05-01T00:00:00.000Z',
+      },
+    } satisfies BillingProfileContract;
+
+    const result = toBillingProfile(contract);
+
+    expect(result.plan).toBe('pro');
+    expect(result.stripeCustomerId).toBe('cus_123');
+    expect(result.subscription?.planCode).toBe('pro');
+    expect(result.subscription?.currentPeriodEnd).toEqual(
+      new Date('2026-05-01T00:00:00.000Z')
+    );
+    expect(result.aiQuota.periodEnd).toEqual(
+      new Date('2026-05-01T00:00:00.000Z')
+    );
+    expect(result.aiQuota.remaining).toBe(38);
+  });
+
+  it('maps a free profile with no subscription and null period dates', () => {
+    const contract = {
+      plan: 'FREE',
+      stripeCustomerId: null,
+      subscription: null,
+      aiQuota: {
+        used: 0,
+        limit: 5,
+        remaining: 5,
+        periodEnd: '2026-05-01T00:00:00.000Z',
+      },
+    } satisfies BillingProfileContract;
+
+    const result = toBillingProfile(contract);
+
+    expect(result.plan).toBe('free');
+    expect(result.stripeCustomerId).toBeNull();
+    expect(result.subscription).toBeNull();
+  });
+
+  it('keeps subscription period boundaries null when absent', () => {
+    const contract = {
+      plan: 'TEAM',
+      stripeCustomerId: 'cus_team',
+      subscription: {
+        id: 'sub_002',
+        status: 'trialing',
+        planCode: 'TEAM',
+        currentPeriodStart: null,
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: true,
+      },
+      aiQuota: {
+        used: 1,
+        limit: 100,
+        remaining: 99,
+        periodEnd: '2026-06-01T00:00:00.000Z',
+      },
+    } satisfies BillingProfileContract;
+
+    const result = toBillingProfile(contract);
+
+    expect(result.plan).toBe('team');
+    expect(result.subscription?.planCode).toBe('team');
+    expect(result.subscription?.currentPeriodStart).toBeNull();
+    expect(result.subscription?.currentPeriodEnd).toBeNull();
+    expect(result.subscription?.cancelAtPeriodEnd).toBe(true);
+  });
+});

--- a/src/modules/billing/data/queries.test.ts
+++ b/src/modules/billing/data/queries.test.ts
@@ -1,0 +1,51 @@
+import { apiClient } from '@/shared/http/api-client';
+import { getBillingProfile } from './queries';
+import type { BillingProfileContract } from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRequest: jest.fn(
+    (callback: (headers: Record<string, string>) => unknown) =>
+      callback({ Authorization: 'Bearer test-token' })
+  ),
+}));
+
+const getMock = jest.mocked(apiClient.get);
+
+describe('billing queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getBillingProfile', () => {
+    it('fetches the current billing profile with auth headers and maps it', async () => {
+      const contract: BillingProfileContract = {
+        plan: 'PRO',
+        stripeCustomerId: 'cus_123',
+        subscription: null,
+        aiQuota: {
+          used: 3,
+          limit: 50,
+          remaining: 47,
+          periodEnd: '2026-05-01T00:00:00.000Z',
+        },
+      };
+      getMock.mockResolvedValueOnce(contract);
+
+      const result = await getBillingProfile();
+
+      expect(getMock).toHaveBeenCalledWith('billing/me', {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+      expect(result.plan).toBe('pro');
+      expect(result.aiQuota.periodEnd).toEqual(
+        new Date('2026-05-01T00:00:00.000Z')
+      );
+    });
+  });
+});

--- a/src/modules/cover-letters/data/mappers.test.ts
+++ b/src/modules/cover-letters/data/mappers.test.ts
@@ -1,0 +1,47 @@
+import type { CoverLetterResponseContract } from './contracts';
+import { toCoverLetter } from './mappers';
+
+describe('toCoverLetter', () => {
+  it('maps the contract and parses timestamps into Dates', () => {
+    const contract = {
+      id: 'cl_001',
+      userId: 'user_001',
+      cvId: 'cv_001',
+      title: 'Application for Acme',
+      content: 'Dear hiring manager...',
+      jobTitle: 'Senior Engineer',
+      company: 'Acme Corp',
+      tone: 'professional',
+      createdAt: '2026-04-01T10:00:00.000Z',
+      updatedAt: '2026-04-02T11:00:00.000Z',
+    } satisfies CoverLetterResponseContract;
+
+    const result = toCoverLetter(contract);
+
+    expect(result.createdAt).toEqual(new Date('2026-04-01T10:00:00.000Z'));
+    expect(result.updatedAt).toEqual(new Date('2026-04-02T11:00:00.000Z'));
+    expect(result.title).toBe('Application for Acme');
+    expect(result.company).toBe('Acme Corp');
+  });
+
+  it('preserves null cv, job title, and company values', () => {
+    const contract = {
+      id: 'cl_002',
+      userId: 'user_001',
+      cvId: null,
+      title: 'Generic letter',
+      content: 'Body',
+      jobTitle: null,
+      company: null,
+      tone: 'casual',
+      createdAt: '2026-04-01T10:00:00.000Z',
+      updatedAt: '2026-04-01T10:00:00.000Z',
+    } satisfies CoverLetterResponseContract;
+
+    const result = toCoverLetter(contract);
+
+    expect(result.cvId).toBeNull();
+    expect(result.jobTitle).toBeNull();
+    expect(result.company).toBeNull();
+  });
+});

--- a/src/modules/cover-letters/data/mutations.test.ts
+++ b/src/modules/cover-letters/data/mutations.test.ts
@@ -1,0 +1,122 @@
+import { apiClient } from '@/shared/http/api-client';
+import {
+  createCoverLetter,
+  deleteCoverLetter,
+  generateCoverLetter,
+  updateCoverLetter,
+} from './mutations';
+import type { CoverLetterResponseContract } from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRequest: jest.fn(
+    (callback: (headers: Record<string, string>) => unknown) =>
+      callback({ Authorization: 'Bearer test-token' })
+  ),
+}));
+
+const postMock = jest.mocked(apiClient.post);
+const patchMock = jest.mocked(apiClient.patch);
+const deleteMock = jest.mocked(apiClient.delete);
+const authHeaders = { Authorization: 'Bearer test-token' };
+
+const letterContract: CoverLetterResponseContract = {
+  id: 'cl_001',
+  userId: 'user_001',
+  cvId: 'cv_001',
+  title: 'Application for Acme',
+  content: 'Dear hiring manager...',
+  jobTitle: 'Senior Engineer',
+  company: 'Acme Corp',
+  tone: 'professional',
+  createdAt: '2026-04-01T10:00:00.000Z',
+  updatedAt: '2026-04-01T10:00:00.000Z',
+};
+
+describe('cover-letters mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createCoverLetter', () => {
+    it('posts the body and maps the created cover letter', async () => {
+      postMock.mockResolvedValueOnce(letterContract);
+
+      const result = await createCoverLetter({ title: 'Application for Acme' });
+
+      expect(postMock).toHaveBeenCalledWith(
+        'cover-letters',
+        { title: 'Application for Acme' },
+        { headers: authHeaders }
+      );
+      expect(result.id).toBe('cl_001');
+      expect(result.createdAt).toEqual(new Date('2026-04-01T10:00:00.000Z'));
+    });
+  });
+
+  describe('updateCoverLetter', () => {
+    it('patches the cover letter by id and maps the result', async () => {
+      patchMock.mockResolvedValueOnce({
+        ...letterContract,
+        title: 'Revised title',
+      });
+
+      const result = await updateCoverLetter('cl_001', {
+        title: 'Revised title',
+      });
+
+      expect(patchMock).toHaveBeenCalledWith(
+        'cover-letters/cl_001',
+        { title: 'Revised title' },
+        { headers: authHeaders }
+      );
+      expect(result.title).toBe('Revised title');
+    });
+  });
+
+  describe('deleteCoverLetter', () => {
+    it('sends a delete request for the cover letter', async () => {
+      deleteMock.mockResolvedValueOnce(undefined);
+
+      await deleteCoverLetter('cl_001');
+
+      expect(deleteMock).toHaveBeenCalledWith('cover-letters/cl_001', {
+        headers: authHeaders,
+      });
+    });
+  });
+
+  describe('generateCoverLetter', () => {
+    it('posts the generation request and returns the raw generated content', async () => {
+      postMock.mockResolvedValueOnce({
+        content: 'Generated body',
+        highlights: ['Tailored to the role'],
+      });
+
+      const result = await generateCoverLetter({
+        cvId: 'cv_001',
+        jobTitle: 'Senior Engineer',
+        template: 'impact_story',
+      });
+
+      expect(postMock).toHaveBeenCalledWith(
+        'cover-letters/generate',
+        {
+          cvId: 'cv_001',
+          jobTitle: 'Senior Engineer',
+          template: 'impact_story',
+        },
+        { headers: authHeaders }
+      );
+      expect(result.content).toBe('Generated body');
+      expect(result.highlights).toEqual(['Tailored to the role']);
+    });
+  });
+});

--- a/src/modules/cover-letters/data/queries.test.ts
+++ b/src/modules/cover-letters/data/queries.test.ts
@@ -1,0 +1,97 @@
+import { apiClient } from '@/shared/http/api-client';
+import { fetchCoverLetter, fetchCoverLetters } from './queries';
+import type {
+  CoverLetterResponseContract,
+  PaginatedCoverLettersContract,
+} from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRequest: jest.fn(
+    (callback: (headers: Record<string, string>) => unknown) =>
+      callback({ Authorization: 'Bearer test-token' })
+  ),
+}));
+
+const getMock = jest.mocked(apiClient.get);
+const authHeaders = { Authorization: 'Bearer test-token' };
+
+const letterContract: CoverLetterResponseContract = {
+  id: 'cl_001',
+  userId: 'user_001',
+  cvId: 'cv_001',
+  title: 'Application for Acme',
+  content: 'Dear hiring manager...',
+  jobTitle: 'Senior Engineer',
+  company: 'Acme Corp',
+  tone: 'professional',
+  createdAt: '2026-04-01T10:00:00.000Z',
+  updatedAt: '2026-04-02T11:00:00.000Z',
+};
+
+describe('cover-letters queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchCoverLetters', () => {
+    it('fetches the first page by default and maps the list', async () => {
+      const page: PaginatedCoverLettersContract = {
+        data: [letterContract],
+        total: 1,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+      };
+      getMock.mockResolvedValueOnce(page);
+
+      const result = await fetchCoverLetters();
+
+      expect(getMock).toHaveBeenCalledWith('cover-letters', {
+        headers: authHeaders,
+        params: { page: 1, limit: 20 },
+      });
+      expect(result.total).toBe(1);
+      expect(result.totalPages).toBe(1);
+      expect(result.data[0].id).toBe('cl_001');
+      expect(result.data[0].createdAt).toEqual(
+        new Date('2026-04-01T10:00:00.000Z')
+      );
+    });
+
+    it('forwards explicit page and limit values', async () => {
+      getMock.mockResolvedValueOnce({
+        data: [],
+        total: 0,
+        page: 3,
+        limit: 5,
+        totalPages: 0,
+      } satisfies PaginatedCoverLettersContract);
+
+      await fetchCoverLetters(3, 5);
+
+      expect(getMock).toHaveBeenCalledWith('cover-letters', {
+        headers: authHeaders,
+        params: { page: 3, limit: 5 },
+      });
+    });
+  });
+
+  describe('fetchCoverLetter', () => {
+    it('fetches a single cover letter by id and maps it', async () => {
+      getMock.mockResolvedValueOnce(letterContract);
+
+      const result = await fetchCoverLetter('cl_001');
+
+      expect(getMock).toHaveBeenCalledWith('cover-letters/cl_001', {
+        headers: authHeaders,
+      });
+      expect(result.title).toBe('Application for Acme');
+    });
+  });
+});

--- a/src/modules/interview/data/mappers.test.ts
+++ b/src/modules/interview/data/mappers.test.ts
@@ -1,0 +1,64 @@
+import type { InterviewQuestionContract } from './contracts';
+import { toInterviewQuestion } from './mappers';
+
+describe('toInterviewQuestion', () => {
+  it('maps a full question and lowercases the difficulty', () => {
+    const contract = {
+      id: 'q_001',
+      question: 'Explain event loop.',
+      sampleAnswer: 'The event loop...',
+      category: 'JavaScript',
+      role: 'Frontend Engineer',
+      difficulty: 'HARD',
+      tips: 'Mention microtasks.',
+    } satisfies InterviewQuestionContract;
+
+    const result = toInterviewQuestion(contract);
+
+    expect(result).toEqual({
+      id: 'q_001',
+      question: 'Explain event loop.',
+      sampleAnswer: 'The event loop...',
+      category: 'JavaScript',
+      role: 'Frontend Engineer',
+      difficulty: 'hard',
+      tips: 'Mention microtasks.',
+    });
+  });
+
+  it('coalesces absent sample answer and tips to null', () => {
+    const contract = {
+      id: 'q_002',
+      question: 'What is closure?',
+      category: 'JavaScript',
+      role: 'Frontend Engineer',
+      difficulty: 'EASY',
+    } satisfies InterviewQuestionContract;
+
+    const result = toInterviewQuestion(contract);
+
+    expect(result.sampleAnswer).toBeNull();
+    expect(result.tips).toBeNull();
+    expect(result.difficulty).toBe('easy');
+  });
+
+  it('maps each difficulty level to its lowercase domain value', () => {
+    const levels = [
+      ['EASY', 'easy'],
+      ['MEDIUM', 'medium'],
+      ['HARD', 'hard'],
+    ] as const;
+
+    for (const [wire, domain] of levels) {
+      const result = toInterviewQuestion({
+        id: 'q',
+        question: 'q?',
+        category: 'c',
+        role: 'r',
+        difficulty: wire,
+      } satisfies InterviewQuestionContract);
+
+      expect(result.difficulty).toBe(domain);
+    }
+  });
+});

--- a/src/modules/interview/data/queries.test.ts
+++ b/src/modules/interview/data/queries.test.ts
@@ -1,0 +1,113 @@
+import { apiClient } from '@/shared/http/api-client';
+import type { PaginatedResponse } from '@/shared/http/paginated-response';
+import {
+  getInterviewCategories,
+  getInterviewQuestions,
+  getInterviewRoles,
+} from './queries';
+import type { InterviewQuestionContract } from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+const getMock = jest.mocked(apiClient.get);
+
+const questionContract: InterviewQuestionContract = {
+  id: 'q_001',
+  question: 'Explain event loop.',
+  category: 'JavaScript',
+  role: 'Frontend Engineer',
+  difficulty: 'HARD',
+};
+
+function paginated(
+  items: InterviewQuestionContract[]
+): PaginatedResponse<InterviewQuestionContract> {
+  return {
+    data: items,
+    meta: {
+      total: items.length,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    },
+  };
+}
+
+describe('interview queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getInterviewQuestions', () => {
+    it('requests with empty params and maps the question list', async () => {
+      getMock.mockResolvedValueOnce(paginated([questionContract]));
+
+      const result = await getInterviewQuestions();
+
+      expect(getMock).toHaveBeenCalledWith('interview/questions', {
+        params: {},
+      });
+      expect(result[0].difficulty).toBe('hard');
+    });
+
+    it('forwards provided filters including the random flag', async () => {
+      getMock.mockResolvedValueOnce(paginated([]));
+
+      await getInterviewQuestions({
+        role: 'Frontend Engineer',
+        category: 'JavaScript',
+        difficulty: 'HARD',
+        random: true,
+        limit: 5,
+      });
+
+      expect(getMock).toHaveBeenCalledWith('interview/questions', {
+        params: {
+          role: 'Frontend Engineer',
+          category: 'JavaScript',
+          difficulty: 'HARD',
+          random: true,
+          limit: 5,
+        },
+      });
+    });
+
+    it('omits the random flag when it is false', async () => {
+      getMock.mockResolvedValueOnce(paginated([]));
+
+      await getInterviewQuestions({ random: false });
+
+      expect(getMock).toHaveBeenCalledWith('interview/questions', {
+        params: {},
+      });
+    });
+  });
+
+  describe('getInterviewRoles', () => {
+    it('returns the raw role list', async () => {
+      getMock.mockResolvedValueOnce(['Frontend Engineer']);
+
+      const result = await getInterviewRoles();
+
+      expect(getMock).toHaveBeenCalledWith('interview/roles');
+      expect(result).toEqual(['Frontend Engineer']);
+    });
+  });
+
+  describe('getInterviewCategories', () => {
+    it('returns the raw category list', async () => {
+      getMock.mockResolvedValueOnce(['JavaScript', 'System Design']);
+
+      const result = await getInterviewCategories();
+
+      expect(getMock).toHaveBeenCalledWith('interview/categories');
+      expect(result).toEqual(['JavaScript', 'System Design']);
+    });
+  });
+});

--- a/src/modules/jobs/data/actions.test.ts
+++ b/src/modules/jobs/data/actions.test.ts
@@ -1,0 +1,192 @@
+import { HttpError } from '@/shared/http/http-error';
+import {
+  createJobAction,
+  createJobNoteAction,
+  deleteJobAction,
+  deleteJobNoteAction,
+  updateJobAction,
+  updateJobStatusAction,
+} from './actions';
+import type { Job, JobNote } from './mappers';
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock('./mutations', () => ({
+  createJob: jest.fn(),
+  updateJob: jest.fn(),
+  updateJobStatus: jest.fn(),
+  deleteJob: jest.fn(),
+  createJobNote: jest.fn(),
+  deleteJobNote: jest.fn(),
+}));
+
+const mutations = jest.requireMock('./mutations') as {
+  createJob: jest.Mock;
+  updateJob: jest.Mock;
+  updateJobStatus: jest.Mock;
+  deleteJob: jest.Mock;
+  createJobNote: jest.Mock;
+  deleteJobNote: jest.Mock;
+};
+
+const { revalidatePath } = jest.requireMock('next/cache') as {
+  revalidatePath: jest.Mock;
+};
+
+const job: Job = {
+  id: 'job_001',
+  title: 'Senior Engineer',
+  company: 'Acme Corp',
+  url: null,
+  location: null,
+  isRemote: false,
+  salaryMin: null,
+  salaryMax: null,
+  salaryCurrency: null,
+  status: 'saved',
+  appliedAt: null,
+  notes: null,
+  createdAt: new Date('2026-04-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-04-01T10:00:00.000Z'),
+  jobNotes: [],
+};
+
+const note: JobNote = {
+  id: 'note_001',
+  content: 'Recruiter call',
+  createdAt: new Date('2026-04-11T08:00:00.000Z'),
+};
+
+describe('jobs actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createJobAction', () => {
+    it('returns the created job and revalidates the jobs list', async () => {
+      mutations.createJob.mockResolvedValueOnce(job);
+
+      const result = await createJobAction({
+        title: 'Senior Engineer',
+        company: 'Acme Corp',
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        data: job,
+        message: 'Job added successfully.',
+      });
+      expect(revalidatePath).toHaveBeenCalledWith('/jobs');
+    });
+
+    it('maps a 403 HttpError to forbidden and does not revalidate', async () => {
+      mutations.createJob.mockRejectedValueOnce(
+        new HttpError(403, 'Forbidden', 'Not allowed')
+      );
+
+      const result = await createJobAction({ title: 't', company: 'c' });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'forbidden',
+        message: 'Not allowed',
+      });
+      expect(revalidatePath).not.toHaveBeenCalled();
+    });
+
+    it('maps a generic error to the unknown fallback', async () => {
+      mutations.createJob.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await createJobAction({ title: 't', company: 'c' });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unknown',
+        message: 'Unable to add the job.',
+      });
+    });
+  });
+
+  describe('updateJobAction', () => {
+    it('returns the updated job with a success message', async () => {
+      mutations.updateJob.mockResolvedValueOnce(job);
+
+      const result = await updateJobAction('job_001', { title: 'Lead' });
+
+      expect(result).toEqual({ ok: true, data: job, message: 'Job updated.' });
+      expect(mutations.updateJob).toHaveBeenCalledWith('job_001', {
+        title: 'Lead',
+      });
+      expect(revalidatePath).toHaveBeenCalledWith('/jobs');
+    });
+  });
+
+  describe('updateJobStatusAction', () => {
+    it('returns the job with a status-updated message', async () => {
+      mutations.updateJobStatus.mockResolvedValueOnce(job);
+
+      const result = await updateJobStatusAction('job_001', {
+        status: 'INTERVIEW',
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        data: job,
+        message: 'Status updated.',
+      });
+    });
+
+    it('maps a 404 HttpError to not_found', async () => {
+      mutations.updateJobStatus.mockRejectedValueOnce(
+        new HttpError(404, 'Not Found', 'Job not found')
+      );
+
+      const result = await updateJobStatusAction('missing', {
+        status: 'OFFER',
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'not_found',
+        message: 'Job not found',
+      });
+    });
+  });
+
+  describe('deleteJobAction', () => {
+    it('returns success and revalidates the jobs list', async () => {
+      mutations.deleteJob.mockResolvedValueOnce(undefined);
+
+      const result = await deleteJobAction('job_001');
+
+      expect(result).toEqual({ ok: true, message: 'Job deleted.' });
+      expect(revalidatePath).toHaveBeenCalledWith('/jobs');
+    });
+  });
+
+  describe('createJobNoteAction', () => {
+    it('returns the created note and revalidates the job detail page', async () => {
+      mutations.createJobNote.mockResolvedValueOnce(note);
+
+      const result = await createJobNoteAction('job_001', {
+        content: 'Recruiter call',
+      });
+
+      expect(result).toEqual({ ok: true, data: note, message: 'Note added.' });
+      expect(revalidatePath).toHaveBeenCalledWith('/jobs/job_001');
+    });
+  });
+
+  describe('deleteJobNoteAction', () => {
+    it('returns success and revalidates the job detail page', async () => {
+      mutations.deleteJobNote.mockResolvedValueOnce(undefined);
+
+      const result = await deleteJobNoteAction('job_001', 'note_001');
+
+      expect(result).toEqual({ ok: true, message: 'Note deleted.' });
+      expect(revalidatePath).toHaveBeenCalledWith('/jobs/job_001');
+    });
+  });
+});

--- a/src/modules/jobs/data/mappers.test.ts
+++ b/src/modules/jobs/data/mappers.test.ts
@@ -1,0 +1,123 @@
+import type {
+  JobResponseContract,
+  JobStatsResponseContract,
+} from './contracts';
+import { toJob, toJobNote, toJobStats } from './mappers';
+
+describe('toJob', () => {
+  it('maps a fully populated job contract into the domain shape', () => {
+    const contract = {
+      id: 'job_001',
+      title: 'Senior Engineer',
+      company: 'Acme Corp',
+      url: 'https://acme.example/jobs/1',
+      location: 'Berlin',
+      isRemote: true,
+      salaryMin: 80000,
+      salaryMax: 120000,
+      salaryCurrency: 'EUR',
+      status: 'APPLIED',
+      appliedAt: '2026-04-10T09:00:00.000Z',
+      notes: 'Referred by a friend',
+      createdAt: '2026-04-01T10:00:00.000Z',
+      updatedAt: '2026-04-12T14:00:00.000Z',
+      jobNotes: [
+        {
+          id: 'note_001',
+          content: 'Phone screen scheduled',
+          createdAt: '2026-04-11T08:00:00.000Z',
+        },
+      ],
+    } satisfies JobResponseContract;
+
+    const result = toJob(contract);
+
+    expect(result.status).toBe('applied');
+    expect(result.url).toBe('https://acme.example/jobs/1');
+    expect(result.salaryMin).toBe(80000);
+    expect(result.appliedAt).toEqual(new Date('2026-04-10T09:00:00.000Z'));
+    expect(result.createdAt).toEqual(new Date('2026-04-01T10:00:00.000Z'));
+    expect(result.updatedAt).toEqual(new Date('2026-04-12T14:00:00.000Z'));
+    expect(result.jobNotes).toHaveLength(1);
+    expect(result.jobNotes[0].content).toBe('Phone screen scheduled');
+  });
+
+  it('coalesces absent optional fields to null and notes to an empty array', () => {
+    const contract = {
+      id: 'job_002',
+      title: 'Junior Developer',
+      company: 'Startup Inc',
+      isRemote: false,
+      status: 'SAVED',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    } satisfies JobResponseContract;
+
+    const result = toJob(contract);
+
+    expect(result.url).toBeNull();
+    expect(result.location).toBeNull();
+    expect(result.salaryMin).toBeNull();
+    expect(result.salaryMax).toBeNull();
+    expect(result.salaryCurrency).toBeNull();
+    expect(result.appliedAt).toBeNull();
+    expect(result.notes).toBeNull();
+    expect(result.jobNotes).toEqual([]);
+  });
+
+  it('lowercases each backend status value', () => {
+    const statuses = [
+      ['SAVED', 'saved'],
+      ['APPLIED', 'applied'],
+      ['INTERVIEW', 'interview'],
+      ['OFFER', 'offer'],
+      ['REJECTED', 'rejected'],
+    ] as const;
+
+    for (const [wire, domain] of statuses) {
+      const result = toJob({
+        id: 'job',
+        title: 't',
+        company: 'c',
+        isRemote: false,
+        status: wire,
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      } satisfies JobResponseContract);
+
+      expect(result.status).toBe(domain);
+    }
+  });
+});
+
+describe('toJobNote', () => {
+  it('parses the createdAt string into a Date', () => {
+    const result = toJobNote({
+      id: 'note_001',
+      content: 'Followed up via email',
+      createdAt: '2026-04-15T12:30:00.000Z',
+    });
+
+    expect(result).toEqual({
+      id: 'note_001',
+      content: 'Followed up via email',
+      createdAt: new Date('2026-04-15T12:30:00.000Z'),
+    });
+  });
+});
+
+describe('toJobStats', () => {
+  it('passes through the aggregate counters', () => {
+    const contract = {
+      total: 12,
+      byStatus: { saved: 4, applied: 5, interview: 3 },
+      appliedThisWeek: 2,
+      pendingInterviews: 3,
+      activeOffers: 1,
+    } satisfies JobStatsResponseContract;
+
+    const result = toJobStats(contract);
+
+    expect(result).toEqual(contract);
+  });
+});

--- a/src/modules/jobs/data/mutations.test.ts
+++ b/src/modules/jobs/data/mutations.test.ts
@@ -1,0 +1,148 @@
+import { apiClient } from '@/shared/http/api-client';
+import {
+  createJob,
+  createJobNote,
+  deleteJob,
+  deleteJobNote,
+  updateJob,
+  updateJobStatus,
+} from './mutations';
+import type { JobResponseContract } from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    post: jest.fn(),
+    patch: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRequest: jest.fn(
+    (callback: (headers: Record<string, string>) => unknown) =>
+      callback({ Authorization: 'Bearer test-token' })
+  ),
+}));
+
+const postMock = jest.mocked(apiClient.post);
+const patchMock = jest.mocked(apiClient.patch);
+const deleteMock = jest.mocked(apiClient.delete);
+
+const authHeaders = { Authorization: 'Bearer test-token' };
+
+const jobContract: JobResponseContract = {
+  id: 'job_001',
+  title: 'Senior Engineer',
+  company: 'Acme Corp',
+  isRemote: false,
+  status: 'SAVED',
+  createdAt: '2026-04-01T10:00:00.000Z',
+  updatedAt: '2026-04-01T10:00:00.000Z',
+};
+
+describe('jobs mutations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createJob', () => {
+    it('posts the job body and maps the created job', async () => {
+      postMock.mockResolvedValueOnce(jobContract);
+
+      const result = await createJob({
+        title: 'Senior Engineer',
+        company: 'Acme Corp',
+      });
+
+      expect(postMock).toHaveBeenCalledWith(
+        'jobs',
+        { title: 'Senior Engineer', company: 'Acme Corp' },
+        { headers: authHeaders }
+      );
+      expect(result.id).toBe('job_001');
+      expect(result.status).toBe('saved');
+    });
+  });
+
+  describe('updateJob', () => {
+    it('patches the job by id with the update body', async () => {
+      patchMock.mockResolvedValueOnce({
+        ...jobContract,
+        title: 'Lead Engineer',
+      });
+
+      const result = await updateJob('job_001', { title: 'Lead Engineer' });
+
+      expect(patchMock).toHaveBeenCalledWith(
+        'jobs/job_001',
+        { title: 'Lead Engineer' },
+        { headers: authHeaders }
+      );
+      expect(result.title).toBe('Lead Engineer');
+    });
+  });
+
+  describe('updateJobStatus', () => {
+    it('patches the status sub-resource and maps the result', async () => {
+      patchMock.mockResolvedValueOnce({ ...jobContract, status: 'INTERVIEW' });
+
+      const result = await updateJobStatus('job_001', { status: 'INTERVIEW' });
+
+      expect(patchMock).toHaveBeenCalledWith(
+        'jobs/job_001/status',
+        { status: 'INTERVIEW' },
+        { headers: authHeaders }
+      );
+      expect(result.status).toBe('interview');
+    });
+  });
+
+  describe('deleteJob', () => {
+    it('sends a delete request for the job', async () => {
+      deleteMock.mockResolvedValueOnce(undefined);
+
+      await deleteJob('job_001');
+
+      expect(deleteMock).toHaveBeenCalledWith('jobs/job_001', {
+        headers: authHeaders,
+      });
+    });
+  });
+
+  describe('createJobNote', () => {
+    it('posts a note under the job and maps it', async () => {
+      postMock.mockResolvedValueOnce({
+        id: 'note_001',
+        content: 'Recruiter call',
+        createdAt: '2026-04-11T08:00:00.000Z',
+      });
+
+      const result = await createJobNote('job_001', {
+        content: 'Recruiter call',
+      });
+
+      expect(postMock).toHaveBeenCalledWith(
+        'jobs/job_001/notes',
+        { content: 'Recruiter call' },
+        { headers: authHeaders }
+      );
+      expect(result).toEqual({
+        id: 'note_001',
+        content: 'Recruiter call',
+        createdAt: new Date('2026-04-11T08:00:00.000Z'),
+      });
+    });
+  });
+
+  describe('deleteJobNote', () => {
+    it('sends a delete request for the nested note', async () => {
+      deleteMock.mockResolvedValueOnce(undefined);
+
+      await deleteJobNote('job_001', 'note_001');
+
+      expect(deleteMock).toHaveBeenCalledWith('jobs/job_001/notes/note_001', {
+        headers: authHeaders,
+      });
+    });
+  });
+});

--- a/src/modules/jobs/data/queries.test.ts
+++ b/src/modules/jobs/data/queries.test.ts
@@ -1,0 +1,115 @@
+import { apiClient } from '@/shared/http/api-client';
+import type { PaginatedResponse } from '@/shared/http/paginated-response';
+import { getJobById, getJobStats, getJobs } from './queries';
+import type {
+  JobResponseContract,
+  JobStatsResponseContract,
+} from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRequest: jest.fn(
+    (callback: (headers: Record<string, string>) => unknown) =>
+      callback({ Authorization: 'Bearer test-token' })
+  ),
+}));
+
+const getMock = jest.mocked(apiClient.get);
+
+const jobContract: JobResponseContract = {
+  id: 'job_001',
+  title: 'Senior Engineer',
+  company: 'Acme Corp',
+  isRemote: true,
+  status: 'APPLIED',
+  createdAt: '2026-04-01T10:00:00.000Z',
+  updatedAt: '2026-04-12T14:00:00.000Z',
+};
+
+function paginated(
+  items: JobResponseContract[]
+): PaginatedResponse<JobResponseContract> {
+  return {
+    data: items,
+    meta: {
+      total: items.length,
+      page: 1,
+      limit: 100,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    },
+  };
+}
+
+describe('jobs queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getJobs', () => {
+    it('fetches jobs with a default limit and maps them to domain jobs', async () => {
+      getMock.mockResolvedValueOnce(paginated([jobContract]));
+
+      const result = await getJobs();
+
+      expect(getMock).toHaveBeenCalledWith('jobs', {
+        headers: { Authorization: 'Bearer test-token' },
+        params: { limit: 100 },
+      });
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('job_001');
+      expect(result[0].status).toBe('applied');
+    });
+
+    it('forwards a status filter as a query param', async () => {
+      getMock.mockResolvedValueOnce(paginated([]));
+
+      await getJobs('APPLIED');
+
+      expect(getMock).toHaveBeenCalledWith('jobs', {
+        headers: { Authorization: 'Bearer test-token' },
+        params: { limit: 100, status: 'APPLIED' },
+      });
+    });
+  });
+
+  describe('getJobById', () => {
+    it('fetches a single job by id and maps it', async () => {
+      getMock.mockResolvedValueOnce(jobContract);
+
+      const result = await getJobById('job_001');
+
+      expect(getMock).toHaveBeenCalledWith('jobs/job_001', {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+      expect(result.company).toBe('Acme Corp');
+    });
+  });
+
+  describe('getJobStats', () => {
+    it('fetches and returns the job statistics', async () => {
+      const stats: JobStatsResponseContract = {
+        total: 7,
+        byStatus: { saved: 3, applied: 4 },
+        appliedThisWeek: 2,
+        pendingInterviews: 1,
+        activeOffers: 0,
+      };
+      getMock.mockResolvedValueOnce(stats);
+
+      const result = await getJobStats();
+
+      expect(getMock).toHaveBeenCalledWith('jobs/stats', {
+        headers: { Authorization: 'Bearer test-token' },
+      });
+      expect(result.total).toBe(7);
+      expect(result.appliedThisWeek).toBe(2);
+    });
+  });
+});

--- a/src/modules/skills/data/actions.test.ts
+++ b/src/modules/skills/data/actions.test.ts
@@ -1,0 +1,152 @@
+import { HttpError } from '@/shared/http/http-error';
+import {
+  assessSkillsAction,
+  fetchRoadmapAction,
+  updateSkillProgressAction,
+} from './actions';
+import type {
+  LearningRoadmap,
+  SkillGapResult,
+  UserSkillProgress,
+} from './mappers';
+
+jest.mock('next/cache', () => ({
+  revalidatePath: jest.fn(),
+}));
+
+jest.mock('./mutations', () => ({
+  assessSkills: jest.fn(),
+  updateSkillProgress: jest.fn(),
+}));
+
+jest.mock('./queries', () => ({
+  getLearningRoadmap: jest.fn(),
+}));
+
+const mutations = jest.requireMock('./mutations') as {
+  assessSkills: jest.Mock;
+  updateSkillProgress: jest.Mock;
+};
+
+const queries = jest.requireMock('./queries') as {
+  getLearningRoadmap: jest.Mock;
+};
+
+const { revalidatePath } = jest.requireMock('next/cache') as {
+  revalidatePath: jest.Mock;
+};
+
+const gapResult: SkillGapResult = {
+  targetRole: 'Backend Engineer',
+  overallReadiness: 70,
+  requiredSkills: [],
+  strengths: [],
+  gaps: [],
+};
+
+const progress: UserSkillProgress = {
+  id: 'prog_001',
+  skillName: 'React',
+  level: 3,
+  status: 'completed',
+  startedAt: null,
+  completedAt: null,
+};
+
+const roadmap: LearningRoadmap = {
+  targetRole: 'DevOps Engineer',
+  totalSkills: 0,
+  completedSkills: 0,
+  milestones: [],
+};
+
+describe('skills actions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('assessSkillsAction', () => {
+    it('returns the assessment result on success', async () => {
+      mutations.assessSkills.mockResolvedValueOnce(gapResult);
+
+      const result = await assessSkillsAction({
+        targetRole: 'Backend Engineer',
+      });
+
+      expect(result).toEqual({ ok: true, data: gapResult });
+      expect(mutations.assessSkills).toHaveBeenCalledWith({
+        targetRole: 'Backend Engineer',
+      });
+    });
+
+    it('maps a generic error to the unknown fallback', async () => {
+      mutations.assessSkills.mockRejectedValueOnce(new Error('boom'));
+
+      const result = await assessSkillsAction({ targetRole: 'x' });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unknown',
+        message: 'Unable to assess your skills.',
+      });
+    });
+  });
+
+  describe('updateSkillProgressAction', () => {
+    it('returns progress and revalidates the skills and roadmap pages', async () => {
+      mutations.updateSkillProgress.mockResolvedValueOnce(progress);
+
+      const result = await updateSkillProgressAction({ skillName: 'React' });
+
+      expect(result).toEqual({
+        ok: true,
+        data: progress,
+        message: 'Progress updated.',
+      });
+      expect(revalidatePath).toHaveBeenCalledWith('/skills');
+      expect(revalidatePath).toHaveBeenCalledWith('/skills/roadmap');
+    });
+
+    it('maps a 401 HttpError to unauthorized and skips revalidation', async () => {
+      mutations.updateSkillProgress.mockRejectedValueOnce(
+        new HttpError(401, 'Unauthorized', 'Session expired')
+      );
+
+      const result = await updateSkillProgressAction({ skillName: 'React' });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unauthorized',
+        message: 'Session expired',
+      });
+      expect(revalidatePath).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchRoadmapAction', () => {
+    it('returns the roadmap from the query on success', async () => {
+      queries.getLearningRoadmap.mockResolvedValueOnce(roadmap);
+
+      const result = await fetchRoadmapAction('DevOps Engineer');
+
+      expect(result).toEqual({ ok: true, data: roadmap });
+      expect(queries.getLearningRoadmap).toHaveBeenCalledWith(
+        'DevOps Engineer'
+      );
+    });
+
+    it('maps a 404 HttpError to not_found', async () => {
+      queries.getLearningRoadmap.mockRejectedValueOnce(
+        new HttpError(404, 'Not Found', 'No roadmap for role')
+      );
+
+      const result = await fetchRoadmapAction('Unknown Role');
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'not_found',
+        message: 'No roadmap for role',
+      });
+    });
+  });
+});

--- a/src/modules/skills/data/mappers.test.ts
+++ b/src/modules/skills/data/mappers.test.ts
@@ -1,0 +1,140 @@
+import type {
+  LearningResourceContract,
+  LearningRoadmapContract,
+  SkillCategoryContract,
+  SkillGapResponseContract,
+  UserSkillProgressContract,
+} from './contracts';
+import {
+  toLearningResource,
+  toLearningRoadmap,
+  toSkillCategory,
+  toSkillGapResult,
+  toUserSkillProgress,
+} from './mappers';
+
+describe('toSkillCategory', () => {
+  it('maps a category and coalesces optional description and icon to null', () => {
+    const contract = {
+      id: 'cat_001',
+      name: 'Frontend',
+    } satisfies SkillCategoryContract;
+
+    expect(toSkillCategory(contract)).toEqual({
+      id: 'cat_001',
+      name: 'Frontend',
+      description: null,
+      icon: null,
+    });
+  });
+});
+
+describe('toSkillGapResult', () => {
+  it('maps required skills and coalesces an absent user level to null', () => {
+    const contract = {
+      targetRole: 'Backend Engineer',
+      overallReadiness: 64,
+      requiredSkills: [
+        {
+          skillName: 'Go',
+          category: 'Languages',
+          importance: 5,
+          hasSkill: false,
+        },
+        {
+          skillName: 'PostgreSQL',
+          category: 'Databases',
+          importance: 4,
+          hasSkill: true,
+          userLevel: 3,
+        },
+      ],
+      strengths: ['PostgreSQL'],
+      gaps: ['Go'],
+    } satisfies SkillGapResponseContract;
+
+    const result = toSkillGapResult(contract);
+
+    expect(result.overallReadiness).toBe(64);
+    expect(result.requiredSkills[0].userLevel).toBeNull();
+    expect(result.requiredSkills[1].userLevel).toBe(3);
+    expect(result.strengths).toEqual(['PostgreSQL']);
+    expect(result.gaps).toEqual(['Go']);
+  });
+});
+
+describe('toUserSkillProgress', () => {
+  it('parses present dates and coalesces absent ones to null', () => {
+    const started = {
+      id: 'prog_001',
+      skillName: 'React',
+      level: 2,
+      status: 'in_progress',
+      startedAt: '2026-04-01T00:00:00.000Z',
+    } satisfies UserSkillProgressContract;
+
+    const result = toUserSkillProgress(started);
+
+    expect(result.startedAt).toEqual(new Date('2026-04-01T00:00:00.000Z'));
+    expect(result.completedAt).toBeNull();
+  });
+});
+
+describe('toLearningResource', () => {
+  it('coalesces an absent duration to null', () => {
+    const contract = {
+      id: 'res_001',
+      skillName: 'Docker',
+      title: 'Docker Basics',
+      url: 'https://learn.example/docker',
+      platform: 'ExampleLearn',
+      difficulty: 'beginner',
+      isFree: true,
+    } satisfies LearningResourceContract;
+
+    expect(toLearningResource(contract).duration).toBeNull();
+  });
+});
+
+describe('toLearningRoadmap', () => {
+  it('maps milestones, nested skills, and their resources', () => {
+    const contract = {
+      targetRole: 'DevOps Engineer',
+      totalSkills: 2,
+      completedSkills: 1,
+      milestones: [
+        {
+          phase: 'Foundations',
+          description: 'Core tooling',
+          skills: [
+            {
+              skillName: 'Linux',
+              importance: 5,
+              status: 'completed',
+              level: 4,
+              resources: [
+                {
+                  id: 'res_010',
+                  skillName: 'Linux',
+                  title: 'Linux CLI',
+                  url: 'https://learn.example/linux',
+                  platform: 'ExampleLearn',
+                  difficulty: 'beginner',
+                  duration: '3h',
+                  isFree: false,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    } satisfies LearningRoadmapContract;
+
+    const result = toLearningRoadmap(contract);
+
+    expect(result.milestones).toHaveLength(1);
+    expect(result.milestones[0].skills[0].skillName).toBe('Linux');
+    expect(result.milestones[0].skills[0].resources[0].duration).toBe('3h');
+    expect(result.milestones[0].skills[0].resources[0].isFree).toBe(false);
+  });
+});

--- a/src/modules/skills/data/queries.test.ts
+++ b/src/modules/skills/data/queries.test.ts
@@ -1,0 +1,143 @@
+import { apiClient } from '@/shared/http/api-client';
+import {
+  getLearningRoadmap,
+  getResources,
+  getSkillCategories,
+  getSkillRoles,
+  getUserProgress,
+} from './queries';
+import type {
+  LearningResourceContract,
+  LearningRoadmapContract,
+  SkillCategoryContract,
+  UserSkillProgressContract,
+} from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRequest: jest.fn(
+    (callback: (headers: Record<string, string>) => unknown) =>
+      callback({ Authorization: 'Bearer test-token' })
+  ),
+}));
+
+const getMock = jest.mocked(apiClient.get);
+const authHeaders = { Authorization: 'Bearer test-token' };
+
+describe('skills queries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getSkillCategories', () => {
+    it('fetches public categories without auth headers and maps them', async () => {
+      const categories: SkillCategoryContract[] = [
+        { id: 'cat_001', name: 'Frontend' },
+      ];
+      getMock.mockResolvedValueOnce(categories);
+
+      const result = await getSkillCategories();
+
+      expect(getMock).toHaveBeenCalledWith('skills/categories');
+      expect(result[0]).toEqual({
+        id: 'cat_001',
+        name: 'Frontend',
+        description: null,
+        icon: null,
+      });
+    });
+  });
+
+  describe('getSkillRoles', () => {
+    it('returns the raw role list from the backend', async () => {
+      getMock.mockResolvedValueOnce(['Frontend Engineer', 'Data Scientist']);
+
+      const result = await getSkillRoles();
+
+      expect(getMock).toHaveBeenCalledWith('skills/roles');
+      expect(result).toEqual(['Frontend Engineer', 'Data Scientist']);
+    });
+  });
+
+  describe('getResources', () => {
+    it('omits empty filter params', async () => {
+      getMock.mockResolvedValueOnce([]);
+
+      await getResources();
+
+      expect(getMock).toHaveBeenCalledWith('skills/resources', { params: {} });
+    });
+
+    it('passes skill and difficulty filters when provided', async () => {
+      const resources: LearningResourceContract[] = [
+        {
+          id: 'res_001',
+          skillName: 'Docker',
+          title: 'Docker Basics',
+          url: 'https://learn.example/docker',
+          platform: 'ExampleLearn',
+          difficulty: 'beginner',
+          isFree: true,
+        },
+      ];
+      getMock.mockResolvedValueOnce(resources);
+
+      const result = await getResources('Docker', 'beginner');
+
+      expect(getMock).toHaveBeenCalledWith('skills/resources', {
+        params: { skill: 'Docker', difficulty: 'beginner' },
+      });
+      expect(result[0].duration).toBeNull();
+    });
+  });
+
+  describe('getUserProgress', () => {
+    it('fetches progress with auth headers and maps dates', async () => {
+      const progress: UserSkillProgressContract[] = [
+        {
+          id: 'prog_001',
+          skillName: 'React',
+          level: 3,
+          status: 'completed',
+          startedAt: '2026-04-01T00:00:00.000Z',
+          completedAt: '2026-05-01T00:00:00.000Z',
+        },
+      ];
+      getMock.mockResolvedValueOnce(progress);
+
+      const result = await getUserProgress();
+
+      expect(getMock).toHaveBeenCalledWith('skills/progress', {
+        headers: authHeaders,
+      });
+      expect(result[0].completedAt).toEqual(
+        new Date('2026-05-01T00:00:00.000Z')
+      );
+    });
+  });
+
+  describe('getLearningRoadmap', () => {
+    it('fetches the roadmap for a role with auth headers and a role param', async () => {
+      const roadmap: LearningRoadmapContract = {
+        targetRole: 'DevOps Engineer',
+        totalSkills: 1,
+        completedSkills: 0,
+        milestones: [],
+      };
+      getMock.mockResolvedValueOnce(roadmap);
+
+      const result = await getLearningRoadmap('DevOps Engineer');
+
+      expect(getMock).toHaveBeenCalledWith('skills/roadmap', {
+        headers: authHeaders,
+        params: { role: 'DevOps Engineer' },
+      });
+      expect(result.targetRole).toBe('DevOps Engineer');
+    });
+  });
+});


### PR DESCRIPTION
## test: backfill co-located data-layer tests (Roadmap Phase 2)

Executes **Roadmap Phase 2 — Test coverage backfill**. Adds the co-located
`.test.ts` files required by the AGENTS.md "every `data/` file ships a test" rule
for the six modules that had none.

### What's added (17 test suites · 78 tests)

| Module `data/` | Tests |
| --- | --- |
| `ai` | mappers, actions |
| `jobs` | mappers, queries, mutations, actions |
| `skills` | mappers, queries, actions |
| `interview` | mappers, queries |
| `cover-letters` | mappers, queries, mutations |
| `billing` | mappers, queries, actions |

### Approach

Follows the established pattern (`cv`/`auth`/`ats`) per the `feature-module` skill:
mock `@/shared/http/api-client` and `executeAuthenticatedRequest`/`cookies`/
`revalidatePath` at the boundary, `satisfies <Contract>` on fixtures, assert
behavior (status/date mapping, null-coalescing, `HttpError` → semantic code,
revalidation paths) not implementation. Fixtures mirror each module's real
contract shapes.

### Scope

Tests only — **no source files changed**. Suite total: 14 → 31 suites, 66 → 144 tests.

### Verification

`pnpm verify` passes (format:check + lint + typecheck + test + build).

### Follow-up (not in this PR)

The roadmap's per-module list omits four source files the blanket AGENTS.md rule
would also cover: `ai/mutations.ts`, `skills/mutations.ts`, `billing/mutations.ts`,
`cover-letters/actions.ts`. Flagged for a roadmap note.

Release impact: `test:` → no release.