### PR TITLE
fix: verify admin role against backend instead of trusting user-profile cookie

### DIFF
--- a/src/app/(site)/admin/page.tsx
+++ b/src/app/(site)/admin/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { getCurrentUser } from '@/modules/auth/data/queries';
+import { getVerifiedCurrentUser } from '@/modules/auth/data/queries';
 import {
   getFeatureFlagList,
   getUnleashServiceStatus,
@@ -22,7 +22,7 @@ export const metadata = {
 };
 
 export default async function AdminPage() {
-  const user = await getCurrentUser();
+  const user = await getVerifiedCurrentUser();
   if (!user) {
     redirect('/login?redirect=/admin');
   }

--- a/src/modules/auth/data/queries.test.ts
+++ b/src/modules/auth/data/queries.test.ts
@@ -1,8 +1,23 @@
 import { cookies } from 'next/headers';
-import { getCurrentUser, isAuthenticated } from './queries';
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRead } from '@/shared/auth/execute-authenticated-request';
+import {
+  getCurrentUser,
+  getVerifiedCurrentUser,
+  isAuthenticated,
+} from './queries';
+import type { UserProfileContract } from './contracts';
 
 jest.mock('next/headers', () => ({
   cookies: jest.fn(),
+}));
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: { get: jest.fn() },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRead: jest.fn(),
 }));
 
 type CookieStore = {
@@ -29,6 +44,8 @@ describe('auth queries', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
+
+  // ─── getCurrentUser (cookie-based, display only) ────────────────────────────
 
   it('returns null when the user profile cookie is missing', async () => {
     const cookieStore = createCookieStore();
@@ -79,5 +96,71 @@ describe('auth queries', () => {
 
     await expect(isAuthenticated()).resolves.toBe(true);
     expect(cookieStore.has).toHaveBeenCalledWith('access-token');
+  });
+
+  // ─── getVerifiedCurrentUser (backend-verified, use for authorization) ────────
+
+  it('fetches and maps the current user from the backend', async () => {
+    const backendContract = {
+      id: 'user_456',
+      email: 'admin@example.com',
+      name: 'Admin User',
+      role: 'PLATFORM_ADMIN',
+      emailVerified: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+    } satisfies UserProfileContract;
+
+    jest
+      .mocked(executeAuthenticatedRead)
+      .mockImplementation((operation) =>
+        operation({ Authorization: 'Bearer test-token' })
+      );
+    jest.mocked(apiClient.get).mockResolvedValue(backendContract);
+
+    await expect(getVerifiedCurrentUser()).resolves.toEqual({
+      id: 'user_456',
+      email: 'admin@example.com',
+      name: 'Admin User',
+      role: 'admin',
+      emailVerified: true,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+
+    expect(apiClient.get).toHaveBeenCalledWith('users/me', {
+      headers: { Authorization: 'Bearer test-token' },
+    });
+  });
+
+  it('maps a regular user role correctly from the backend', async () => {
+    const backendContract = {
+      id: 'user_789',
+      email: 'user@example.com',
+      name: 'Regular User',
+      role: 'REGULAR',
+      emailVerified: true,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } satisfies UserProfileContract;
+
+    jest
+      .mocked(executeAuthenticatedRead)
+      .mockImplementation((operation) =>
+        operation({ Authorization: 'Bearer test-token' })
+      );
+    jest.mocked(apiClient.get).mockResolvedValue(backendContract);
+
+    const result = await getVerifiedCurrentUser();
+
+    expect(result?.role).toBe('regular');
+  });
+
+  it('returns null when the backend request fails (unauthenticated or network error)', async () => {
+    jest
+      .mocked(executeAuthenticatedRead)
+      .mockRejectedValue(new Error('Unauthorized'));
+
+    await expect(getVerifiedCurrentUser()).resolves.toBeNull();
   });
 });

--- a/src/modules/auth/data/queries.ts
+++ b/src/modules/auth/data/queries.ts
@@ -1,16 +1,23 @@
+import 'server-only';
+
 import { cookies } from 'next/headers';
-import { parseUserProfileFromJson, type UserProfile } from './mappers';
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRead } from '@/shared/auth/execute-authenticated-request';
+import {
+  parseUserProfileFromJson,
+  toUserProfile,
+  type UserProfile,
+} from './mappers';
+import type { UserProfileContract } from './contracts';
 
 /**
  * Returns the current authenticated user's profile from the session cookie,
  * or null if the user is not logged in.
  *
- * This reads from the httpOnly cookie set by the login Server Action.
- * No network call is made — the profile is stored alongside the token
- * on successful authentication.
- *
- * When the backend exposes a /auth/user/me endpoint, replace this with
- * a direct apiClient call using readAuthHeader().
+ * Fast (no network). Suitable for display-only use cases such as the app
+ * shell, navbar, and dashboard headers. Do NOT use for authorization
+ * decisions — the cookie is populated client-side during OAuth and its
+ * `role` field is unverified. Use `getVerifiedCurrentUser()` instead.
  */
 export async function getCurrentUser(): Promise<UserProfile | null> {
   const cookieStore = await cookies();
@@ -33,4 +40,28 @@ export async function getCurrentUser(): Promise<UserProfile | null> {
 export async function isAuthenticated(): Promise<boolean> {
   const cookieStore = await cookies();
   return cookieStore.has('access-token');
+}
+
+/**
+ * Fetches the current user's profile directly from the backend and returns
+ * it, or null if unauthenticated or the request fails.
+ *
+ * Use this wherever the result is used for an authorization decision
+ * (e.g. role-gating a route) — the backend validates the JWT and returns
+ * the authoritative role, so the response cannot be forged client-side.
+ *
+ * Avoid calling this on every page render — reserve it for server-side
+ * gates where trust matters, not display-only data.
+ */
+export async function getVerifiedCurrentUser(): Promise<UserProfile | null> {
+  try {
+    return await executeAuthenticatedRead(async (headers) => {
+      const contract = await apiClient.get<UserProfileContract>('users/me', {
+        headers,
+      });
+      return toUserProfile(contract);
+    });
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
The admin gate in /admin relied on getCurrentUser() which reads role from the user-profile cookie. That cookie is populated client-side during OAuth (url hash → Server Action) and its role field was never cross-checked against the access token — an attacker could forge role:"admin" in the OAuth payload and bypass the gate.

Add getVerifiedCurrentUser() to auth/data/queries that calls GET users/me through executeAuthenticatedRead. The backend validates the JWT and returns the authoritative role. Admin page now uses this for its authorization check.

Also adds server-only guard to auth/data/queries (was missing) and expands the queries test suite with backend-verified path coverage.