### PR TITLE
Refactor/audit cleanup

### DIFF
--- a/src/app/(site)/ats-scorer/ats-scorer-page-client.tsx
+++ b/src/app/(site)/ats-scorer/ats-scorer-page-client.tsx
@@ -42,7 +42,7 @@ export function AtsScorerPageClient() {
         toast.error(res.message);
         return;
       }
-      setResult(res.data);
+      setResult(res.data ?? null);
       toast.success('ATS score ready.');
     } catch {
       toast.error('Something went wrong. Please try again.');

--- a/src/app/auth/oauth-callback/page.tsx
+++ b/src/app/auth/oauth-callback/page.tsx
@@ -24,7 +24,21 @@ export default function OAuthCallbackPage() {
           return atob(`${normalized}${padding}`);
         };
 
+        // Read the fragment then immediately scrub it from the URL so the
+        // raw token payload does not linger in the address bar or browser
+        // history while the async persistOAuthSessionAction call is in-flight.
+        //
+        // NOTE: The root risk (tokens passing through the client URL at all)
+        // requires a backend fix: switch the OAuth callback to a server-side
+        // redirect that sets httpOnly session cookies directly, rather than
+        // encoding tokens in the URL fragment.
         const hash = window.location.hash;
+        history.replaceState(
+          null,
+          '',
+          window.location.pathname + window.location.search
+        );
+
         const tokenParam = hash
           .slice(1)
           .split('&')

--- a/src/components/common/grammar-check-inline.tsx
+++ b/src/components/common/grammar-check-inline.tsx
@@ -40,6 +40,7 @@ export function GrammarCheckInline({
         toast.error(result.message);
         return;
       }
+      if (!result.data) return;
       setSummary(result.data.summary);
       setIssues(
         result.data.issues.map((i) => ({

--- a/src/modules/ai/data/actions.test.ts
+++ b/src/modules/ai/data/actions.test.ts
@@ -112,9 +112,25 @@ describe('ai actions', () => {
       });
     });
 
-    it('maps failures to the unknown fallback for optimization', async () => {
+    it('maps a 500 HttpError to unknown with the server message', async () => {
       mutations.optimizeCvForJob.mockRejectedValueOnce(
         new HttpError(500, 'Internal', 'Model timeout')
+      );
+
+      const result = await optimizeCvAction('cv_001', {
+        jobDescription: 'x',
+      });
+
+      expect(result).toEqual({
+        ok: false,
+        code: 'unknown',
+        message: 'Model timeout',
+      });
+    });
+
+    it('maps a generic error to unknown with the fallback message', async () => {
+      mutations.optimizeCvForJob.mockRejectedValueOnce(
+        new Error('Network failure')
       );
 
       const result = await optimizeCvAction('cv_001', {

--- a/src/modules/ats/data/actions.test.ts
+++ b/src/modules/ats/data/actions.test.ts
@@ -1,0 +1,62 @@
+import { scoreAts } from './mutations';
+import { scoreAtsAction } from './actions';
+import type { AtsScoreResult } from './mappers';
+import { HttpError } from '@/shared/http/http-error';
+
+jest.mock('./mutations', () => ({ scoreAts: jest.fn() }));
+
+const mockResult: AtsScoreResult = {
+  overallScore: 85,
+  keywordMatches: [
+    { keyword: 'TypeScript', found: true, importance: 'required' },
+  ],
+  sectionScores: [{ name: 'Skills', score: 80, feedback: 'Good coverage.' }],
+  missingKeywords: ['GraphQL'],
+  suggestions: ['Add GraphQL experience'],
+  keywordMatchRate: 0.9,
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('scoreAtsAction', () => {
+  it('returns ok:true with the ATS score result on success', async () => {
+    jest.mocked(scoreAts).mockResolvedValue(mockResult);
+
+    const result = await scoreAtsAction({
+      cvText: 'My CV text',
+      jobDescription: 'Job description text',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual(mockResult);
+  });
+
+  it('returns ok:false with code:unauthorized on a 401 error', async () => {
+    jest
+      .mocked(scoreAts)
+      .mockRejectedValue(new HttpError(401, 'Unauthorized', 'Token expired'));
+
+    const result = await scoreAtsAction({
+      cvText: 'cv',
+      jobDescription: 'jd',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('unauthorized');
+      expect(result.message).toBe('Token expired');
+    }
+  });
+
+  it('returns ok:false with code:unknown on an unexpected error', async () => {
+    jest.mocked(scoreAts).mockRejectedValue(new Error('Network failure'));
+
+    const result = await scoreAtsAction({
+      cvText: 'cv',
+      jobDescription: 'jd',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('unknown');
+  });
+});

--- a/src/modules/ats/data/actions.ts
+++ b/src/modules/ats/data/actions.ts
@@ -1,49 +1,17 @@
 'use server';
 
-import { HttpError } from '@/shared/http/http-error';
+import { toFailureResult, type ActionResult } from '@/shared/action-result';
 import { scoreAts } from './mutations';
 import type { AtsScoreRequest } from './contracts';
 import type { AtsScoreResult } from './mappers';
 
-export type AtsActionCode = 'unauthorized' | 'validation' | 'unknown';
-
-export interface AtsActionSuccess {
-  ok: true;
-  data: AtsScoreResult;
-}
-
-export interface AtsActionFailure {
-  ok: false;
-  code: AtsActionCode;
-  message: string;
-}
-
-export type AtsScoreActionResult = AtsActionSuccess | AtsActionFailure;
-
-function toFailure(error: unknown, fallback: string): AtsActionFailure {
-  if (error instanceof HttpError) {
-    if (error.isUnauthorized) {
-      return {
-        ok: false,
-        code: 'unauthorized',
-        message: error.serverMessage ?? error.message,
-      };
-    }
-  }
-  return {
-    ok: false,
-    code: 'unknown',
-    message: error instanceof Error && error.message ? error.message : fallback,
-  };
-}
-
 export async function scoreAtsAction(
   input: AtsScoreRequest
-): Promise<AtsScoreActionResult> {
+): Promise<ActionResult<AtsScoreResult>> {
   try {
     const data = await scoreAts(input);
     return { ok: true, data };
   } catch (error) {
-    return toFailure(error, 'Unable to score this match-up right now.');
+    return toFailureResult(error, 'Unable to score this match-up right now.');
   }
 }

--- a/src/modules/auth/data/mutations.ts
+++ b/src/modules/auth/data/mutations.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import { apiClient } from '@/shared/http/api-client';
 import { HttpError } from '@/shared/http/http-error';
 import type {

--- a/src/modules/auth/data/queries.ts
+++ b/src/modules/auth/data/queries.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import { cookies } from 'next/headers';
 import { parseUserProfileFromJson, type UserProfile } from './mappers';
 

--- a/src/modules/cv/data/actions.test.ts
+++ b/src/modules/cv/data/actions.test.ts
@@ -187,7 +187,7 @@ describe('cv actions', () => {
       expect(result).toEqual({
         ok: false,
         code: 'unknown',
-        message: 'Network failure',
+        message: 'Unable to create your CV right now.',
       });
     });
 

--- a/src/modules/cv/data/actions.ts
+++ b/src/modules/cv/data/actions.ts
@@ -1,7 +1,11 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { HttpError } from '@/shared/http/http-error';
+import {
+  toFailureResult,
+  type ActionFailureResult,
+  type ActionResult,
+} from '@/shared/action-result';
 import type {
   CreateCvRequest,
   ImportLinkedInToCvRequest,
@@ -51,77 +55,6 @@ import type {
   ProjectItemRequest,
   SkillItemRequest,
 } from './contracts';
-
-// ─── Action types ─────────────────────────────────────────────────────────────
-
-export type CvActionCode =
-  | 'not_found'
-  | 'forbidden'
-  | 'conflict'
-  | 'unauthorized'
-  | 'unknown';
-
-export interface ActionSuccessResult<T = undefined> {
-  ok: true;
-  message?: string;
-  redirectTo?: string;
-  data?: T;
-}
-
-export interface ActionFailureResult {
-  ok: false;
-  code: CvActionCode;
-  message: string;
-}
-
-export type ActionResult<T = undefined> =
-  | ActionSuccessResult<T>
-  | ActionFailureResult;
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof HttpError) {
-    return error.serverMessage ?? error.message;
-  }
-
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-
-  return fallback;
-}
-
-function toFailureResult(
-  error: unknown,
-  fallbackMessage: string
-): ActionFailureResult {
-  if (error instanceof HttpError) {
-    const message = getErrorMessage(error, fallbackMessage);
-
-    if (error.isNotFound) {
-      return { ok: false, code: 'not_found', message };
-    }
-
-    if (error.isForbidden) {
-      return { ok: false, code: 'forbidden', message };
-    }
-
-    if (error.isConflict) {
-      return { ok: false, code: 'conflict', message };
-    }
-
-    if (error.isUnauthorized) {
-      return { ok: false, code: 'unauthorized', message };
-    }
-  }
-
-  return {
-    ok: false,
-    code: 'unknown',
-    message: getErrorMessage(error, fallbackMessage),
-  };
-}
 
 // ─── CV actions ───────────────────────────────────────────────────────────────
 

--- a/src/modules/cv/data/mutations.ts
+++ b/src/modules/cv/data/mutations.ts
@@ -1,7 +1,6 @@
 import 'server-only';
 
 import { apiClient, getApiClient } from '@/shared/http/api-client';
-import { env } from '@/shared/config/env';
 import { HttpError } from '@/shared/http/http-error';
 import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
 
@@ -274,31 +273,12 @@ export async function importCvFromFile(file: File): Promise<Cv> {
 
 export async function exportCvPdf(cvId: string): Promise<Blob> {
   assertSafeCvId(cvId);
+  const safeCvId = encodeURIComponent(cvId);
 
   return executeAuthenticatedRequest(async (headers) => {
-    const baseUrl = env.apiBaseUrl.endsWith('/')
-      ? env.apiBaseUrl
-      : `${env.apiBaseUrl}/`;
-    const safeCvId = encodeURIComponent(cvId);
-    const url = `${baseUrl}cv/${safeCvId}/export/pdf`;
-
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: {
-        ...headers,
-        Accept: 'application/pdf',
-      },
+    return apiClient.getBlob(`cv/${safeCvId}/export/pdf`, {
+      headers: { ...headers, Accept: 'application/pdf' },
     });
-
-    if (!response.ok) {
-      throw new HttpError(
-        response.status,
-        response.statusText,
-        'Failed to export PDF'
-      );
-    }
-
-    return response.blob();
   });
 }
 

--- a/src/modules/features/data/actions.ts
+++ b/src/modules/features/data/actions.ts
@@ -4,29 +4,9 @@ import { revalidatePath } from 'next/cache';
 import { HttpError } from '@/shared/http/http-error';
 import { refreshUnleashFeaturesFromServer } from './mutations';
 
-export type FeatureActionFailure = {
-  ok: false;
-  message: string;
-};
-
-export type FeatureActionSuccess = {
-  ok: true;
-  message: string;
-};
-
 export type RefreshFeaturesActionResult =
-  | FeatureActionSuccess
-  | FeatureActionFailure;
-
-function getErrorMessage(error: unknown, fallback: string): string {
-  if (error instanceof HttpError) {
-    return error.serverMessage ?? error.message;
-  }
-  if (error instanceof Error && error.message) {
-    return error.message;
-  }
-  return fallback;
-}
+  | { ok: true; message: string }
+  | { ok: false; message: string };
 
 export async function refreshUnleashFeaturesAction(): Promise<RefreshFeaturesActionResult> {
   try {
@@ -37,12 +17,12 @@ export async function refreshUnleashFeaturesAction(): Promise<RefreshFeaturesAct
       message: payload.message ?? 'Feature flags refresh initiated.',
     };
   } catch (error) {
-    return {
-      ok: false,
-      message: getErrorMessage(
-        error,
-        'Unable to refresh flags. Sign in with a platform admin session that can call the refresh API.'
-      ),
-    };
+    const message =
+      error instanceof HttpError
+        ? (error.serverMessage ?? error.message)
+        : error instanceof Error && error.message
+          ? error.message
+          : 'Unable to refresh flags. Sign in with a platform admin session that can call the refresh API.';
+    return { ok: false, message };
   }
 }

--- a/src/modules/grammar/data/actions.test.ts
+++ b/src/modules/grammar/data/actions.test.ts
@@ -1,0 +1,57 @@
+import { checkGrammar } from './mutations';
+import { checkGrammarAction } from './actions';
+import type { GrammarCheckResult } from './mappers';
+import { HttpError } from '@/shared/http/http-error';
+
+jest.mock('./mutations', () => ({ checkGrammar: jest.fn() }));
+
+const mockResult: GrammarCheckResult = {
+  score: 92,
+  issues: [
+    {
+      type: 'grammar',
+      message: 'Possible typo',
+      suggestion: 'the',
+      startIndex: 0,
+      endIndex: 3,
+      severity: 'warning',
+    },
+  ],
+  summary: 'Minor issues found.',
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('checkGrammarAction', () => {
+  it('returns ok:true with grammar check result on success', async () => {
+    jest.mocked(checkGrammar).mockResolvedValue(mockResult);
+
+    const result = await checkGrammarAction({ text: 'Check teh text.' });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.data).toEqual(mockResult);
+  });
+
+  it('returns ok:false with code:unauthorized on a 401', async () => {
+    jest
+      .mocked(checkGrammar)
+      .mockRejectedValue(new HttpError(401, 'Unauthorized', 'Session expired'));
+
+    const result = await checkGrammarAction({ text: 'text' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.code).toBe('unauthorized');
+      expect(result.message).toBe('Session expired');
+    }
+  });
+
+  it('returns ok:false with code:unknown for non-HTTP errors', async () => {
+    jest.mocked(checkGrammar).mockRejectedValue(new Error('timeout'));
+
+    const result = await checkGrammarAction({ text: 'text' });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.code).toBe('unknown');
+  });
+});

--- a/src/modules/grammar/data/actions.ts
+++ b/src/modules/grammar/data/actions.ts
@@ -1,49 +1,17 @@
 'use server';
 
-import { HttpError } from '@/shared/http/http-error';
+import { toFailureResult, type ActionResult } from '@/shared/action-result';
 import { checkGrammar } from './mutations';
 import type { CheckGrammarRequest } from './contracts';
 import type { GrammarCheckResult } from './mappers';
 
-export type GrammarActionCode = 'unauthorized' | 'unknown';
-
-export interface GrammarActionSuccess {
-  ok: true;
-  data: GrammarCheckResult;
-}
-
-export interface GrammarActionFailure {
-  ok: false;
-  code: GrammarActionCode;
-  message: string;
-}
-
-export type GrammarCheckActionResult =
-  | GrammarActionSuccess
-  | GrammarActionFailure;
-
-function toFailure(error: unknown, fallback: string): GrammarActionFailure {
-  if (error instanceof HttpError && error.isUnauthorized) {
-    return {
-      ok: false,
-      code: 'unauthorized',
-      message: error.serverMessage ?? error.message,
-    };
-  }
-  return {
-    ok: false,
-    code: 'unknown',
-    message: error instanceof Error && error.message ? error.message : fallback,
-  };
-}
-
 export async function checkGrammarAction(
   input: CheckGrammarRequest
-): Promise<GrammarCheckActionResult> {
+): Promise<ActionResult<GrammarCheckResult>> {
   try {
     const data = await checkGrammar(input);
     return { ok: true, data };
   } catch (error) {
-    return toFailure(error, 'Unable to check grammar right now.');
+    return toFailureResult(error, 'Unable to check grammar right now.');
   }
 }

--- a/src/modules/user/data/actions.ts
+++ b/src/modules/user/data/actions.ts
@@ -1,62 +1,24 @@
 'use server';
 
-import { HttpError } from '@/shared/http/http-error';
 import { clearAuthSession } from '@/modules/auth/data/session';
+import { toFailureResult, type ActionResult } from '@/shared/action-result';
 import { deleteAccount, updateProfile, uploadAvatar } from './mutations';
-
-type UserActionCode = 'not_found' | 'unauthorized' | 'unknown';
-
-interface ActionSuccessResult {
-  ok: true;
-  message?: string;
-  redirectTo?: string;
-}
-
-interface ActionFailureResult {
-  ok: false;
-  code: UserActionCode;
-  message: string;
-}
-
-export type UserActionResult = ActionSuccessResult | ActionFailureResult;
-
-function toUserFailureResult(
-  error: unknown,
-  fallbackMessage: string
-): ActionFailureResult {
-  if (error instanceof HttpError) {
-    const message = error.serverMessage ?? error.message;
-
-    if (error.isNotFound) {
-      return { ok: false, code: 'not_found', message };
-    }
-
-    if (error.isUnauthorized) {
-      return { ok: false, code: 'unauthorized', message };
-    }
-  }
-
-  const message =
-    error instanceof Error && error.message ? error.message : fallbackMessage;
-
-  return { ok: false, code: 'unknown', message };
-}
 
 export async function updateProfileAction(input: {
   name?: string;
   avatarUrl?: string;
-}): Promise<UserActionResult> {
+}): Promise<ActionResult> {
   try {
     await updateProfile(input);
     return { ok: true, message: 'Profile updated successfully' };
   } catch (error) {
-    return toUserFailureResult(error, 'Failed to update profile');
+    return toFailureResult(error, 'Failed to update profile');
   }
 }
 
 export async function uploadAvatarAction(
   formData: FormData
-): Promise<UserActionResult> {
+): Promise<ActionResult> {
   const file = formData.get('avatar');
 
   if (!(file instanceof File) || file.size === 0) {
@@ -72,25 +34,25 @@ export async function uploadAvatarAction(
     await updateProfile({ avatarUrl });
     return { ok: true, message: 'Profile photo updated successfully' };
   } catch (error) {
-    return toUserFailureResult(error, 'Failed to upload profile photo');
+    return toFailureResult(error, 'Failed to upload profile photo');
   }
 }
 
-export async function removeAvatarAction(): Promise<UserActionResult> {
+export async function removeAvatarAction(): Promise<ActionResult> {
   try {
     await updateProfile({ avatarUrl: '' });
     return { ok: true, message: 'Profile photo removed successfully' };
   } catch (error) {
-    return toUserFailureResult(error, 'Failed to remove profile photo');
+    return toFailureResult(error, 'Failed to remove profile photo');
   }
 }
 
-export async function deleteAccountAction(): Promise<UserActionResult> {
+export async function deleteAccountAction(): Promise<ActionResult> {
   try {
     await deleteAccount();
     await clearAuthSession();
     return { ok: true, redirectTo: '/' };
   } catch (error) {
-    return toUserFailureResult(error, 'Failed to delete account');
+    return toFailureResult(error, 'Failed to delete account');
   }
 }

--- a/src/modules/user/data/mappers.test.ts
+++ b/src/modules/user/data/mappers.test.ts
@@ -1,0 +1,58 @@
+import { toUserProfile } from './mappers';
+import type { UserProfileResponseContract } from './contracts';
+
+const baseContract = {
+  id: 'user_123',
+  email: 'user@example.com',
+  name: 'Alice Smith',
+  role: 'REGULAR',
+  emailVerified: true,
+  avatarUrl: 'https://cdn.example.com/avatar.jpg',
+  provider: 'google',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-02T00:00:00.000Z',
+} satisfies UserProfileResponseContract;
+
+describe('toUserProfile', () => {
+  it('maps a full contract to a UserProfile domain object', () => {
+    const result = toUserProfile(baseContract);
+
+    expect(result).toEqual({
+      id: 'user_123',
+      email: 'user@example.com',
+      name: 'Alice Smith',
+      role: 'regular',
+      emailVerified: true,
+      avatarUrl: 'https://cdn.example.com/avatar.jpg',
+      provider: 'google',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-02T00:00:00.000Z'),
+    });
+  });
+
+  it('lowercases the role field', () => {
+    const result = toUserProfile({ ...baseContract, role: 'PLATFORM_ADMIN' });
+    expect(result.role).toBe('platform_admin');
+  });
+
+  it('maps null optional fields when absent', () => {
+    const result = toUserProfile({
+      ...baseContract,
+      name: undefined,
+      avatarUrl: undefined,
+      provider: undefined,
+    });
+
+    expect(result.name).toBeNull();
+    expect(result.avatarUrl).toBeNull();
+    expect(result.provider).toBeNull();
+  });
+
+  it('parses date strings into Date instances', () => {
+    const result = toUserProfile(baseContract);
+
+    expect(result.createdAt).toBeInstanceOf(Date);
+    expect(result.updatedAt).toBeInstanceOf(Date);
+    expect(result.createdAt.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+  });
+});

--- a/src/modules/user/data/mutations.test.ts
+++ b/src/modules/user/data/mutations.test.ts
@@ -1,0 +1,93 @@
+import { apiClient } from '@/shared/http/api-client';
+import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
+import { deleteAccount, updateProfile, uploadAvatar } from './mutations';
+import type {
+  AvatarUploadResponseContract,
+  UserProfileResponseContract,
+} from './contracts';
+
+jest.mock('@/shared/http/api-client', () => ({
+  apiClient: {
+    patch: jest.fn(),
+    postFormData: jest.fn(),
+    delete: jest.fn(),
+  },
+}));
+
+jest.mock('@/shared/auth/execute-authenticated-request', () => ({
+  executeAuthenticatedRequest: jest.fn(),
+}));
+
+const AUTH_HEADERS = { Authorization: 'Bearer test-token' };
+
+function mockAuthRequest(): void {
+  jest
+    .mocked(executeAuthenticatedRequest)
+    .mockImplementation((operation) => operation(AUTH_HEADERS));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAuthRequest();
+});
+
+describe('updateProfile', () => {
+  it('calls PATCH users/me with auth headers and returns a UserProfile', async () => {
+    const contract = {
+      id: 'user_123',
+      email: 'user@example.com',
+      name: 'Alice',
+      role: 'REGULAR',
+      emailVerified: true,
+      avatarUrl: null,
+      provider: null,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } satisfies UserProfileResponseContract;
+
+    jest.mocked(apiClient.patch).mockResolvedValue(contract);
+
+    const result = await updateProfile({ name: 'Alice' });
+
+    expect(apiClient.patch).toHaveBeenCalledWith(
+      'users/me',
+      { name: 'Alice' },
+      { headers: AUTH_HEADERS }
+    );
+    expect(result.name).toBe('Alice');
+    expect(result.role).toBe('regular');
+  });
+});
+
+describe('uploadAvatar', () => {
+  it('appends the file as "avatar" and calls postFormData on users/me/avatar', async () => {
+    const contract = {
+      avatarUrl: 'https://cdn.example.com/new-avatar.jpg',
+    } satisfies AvatarUploadResponseContract;
+
+    jest.mocked(apiClient.postFormData).mockResolvedValue(contract);
+
+    const file = new File(['image data'], 'avatar.png', { type: 'image/png' });
+    const result = await uploadAvatar(file);
+
+    expect(result).toBe('https://cdn.example.com/new-avatar.jpg');
+
+    const [endpoint, formData, config] = jest.mocked(apiClient.postFormData)
+      .mock.calls[0] as [string, FormData, { headers: Record<string, string> }];
+    expect(endpoint).toBe('users/me/avatar');
+    expect(formData.get('avatar')).toBe(file);
+    expect(config.headers).toEqual(AUTH_HEADERS);
+  });
+});
+
+describe('deleteAccount', () => {
+  it('calls DELETE users/me with auth headers', async () => {
+    jest.mocked(apiClient.delete).mockResolvedValue(undefined);
+
+    await deleteAccount();
+
+    expect(apiClient.delete).toHaveBeenCalledWith('users/me', {
+      headers: AUTH_HEADERS,
+    });
+  });
+});

--- a/src/modules/user/data/mutations.ts
+++ b/src/modules/user/data/mutations.ts
@@ -1,8 +1,6 @@
 import 'server-only';
 
 import { apiClient } from '@/shared/http/api-client';
-import { env } from '@/shared/config/env';
-import { HttpError } from '@/shared/http/http-error';
 import { executeAuthenticatedRequest } from '@/shared/auth/execute-authenticated-request';
 import type {
   AvatarUploadResponseContract,
@@ -28,37 +26,12 @@ export async function uploadAvatar(file: File): Promise<string> {
   return executeAuthenticatedRequest(async (headers) => {
     const formData = new FormData();
     formData.append('avatar', file);
-
-    const url = `${env.apiBaseUrl}users/me/avatar`;
-
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        Authorization: headers.Authorization,
-      },
-      body: formData,
-    });
-
-    if (!response.ok) {
-      let errorMessage: string | undefined;
-      let errorName: string = response.statusText;
-      try {
-        const errorBody = (await response.json()) as {
-          error?: string;
-          message?: string;
-        };
-        errorName = errorBody.error ?? response.statusText;
-        errorMessage = errorBody.message;
-      } catch {
-        // non-JSON error response
-      }
-      throw new HttpError(response.status, errorName, errorMessage);
-    }
-
-    const json = (await response.json()) as {
-      data: AvatarUploadResponseContract;
-    };
-    return json.data.avatarUrl;
+    const contract = await apiClient.postFormData<AvatarUploadResponseContract>(
+      'users/me/avatar',
+      formData,
+      { headers }
+    );
+    return contract.avatarUrl;
   });
 }
 

--- a/src/shared/action-result.ts
+++ b/src/shared/action-result.ts
@@ -1,6 +1,12 @@
 import { HttpError } from '@/shared/http/http-error';
 
-export type ActionCode = 'not_found' | 'forbidden' | 'unauthorized' | 'unknown';
+export type ActionCode =
+  | 'not_found'
+  | 'forbidden'
+  | 'conflict'
+  | 'unauthorized'
+  | 'validation'
+  | 'unknown';
 
 export interface ActionSuccessResult<T = undefined> {
   ok: true;
@@ -28,6 +34,7 @@ export function toFailureResult(
 
     if (error.isNotFound) return { ok: false, code: 'not_found', message };
     if (error.isForbidden) return { ok: false, code: 'forbidden', message };
+    if (error.isConflict) return { ok: false, code: 'conflict', message };
     if (error.isUnauthorized)
       return { ok: false, code: 'unauthorized', message };
   }

--- a/src/shared/action-result.ts
+++ b/src/shared/action-result.ts
@@ -42,7 +42,5 @@ export function toFailureResult(
     return { ok: false, code: 'unknown', message };
   }
 
-  const message =
-    error instanceof Error && error.message ? error.message : fallbackMessage;
-  return { ok: false, code: 'unknown', message };
+  return { ok: false, code: 'unknown', message: fallbackMessage };
 }

--- a/src/shared/action-result.ts
+++ b/src/shared/action-result.ts
@@ -37,7 +37,12 @@ export function toFailureResult(
     if (error.isConflict) return { ok: false, code: 'conflict', message };
     if (error.isUnauthorized)
       return { ok: false, code: 'unauthorized', message };
+
+    // Unmapped HTTP status (e.g. 500) — preserve the server message.
+    return { ok: false, code: 'unknown', message };
   }
 
-  return { ok: false, code: 'unknown', message: fallbackMessage };
+  const message =
+    error instanceof Error && error.message ? error.message : fallbackMessage;
+  return { ok: false, code: 'unknown', message };
 }

--- a/src/shared/http/fetch-http-client.ts
+++ b/src/shared/http/fetch-http-client.ts
@@ -190,6 +190,62 @@ export class FetchHttpClient implements HttpClient {
     return this.execute<T>('GET', endpoint, undefined, config);
   }
 
+  async getBlob(endpoint: string, config: RequestConfig = {}): Promise<Blob> {
+    const url = this.buildUrl(endpoint, config.params);
+    const start = Date.now();
+    const safeUrl = sanitizeUrlForLogging(url);
+
+    logger.debug({ method: 'GET', url: safeUrl });
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { ...config.headers },
+      cache: config.cache,
+      next: config.next,
+    });
+
+    const correlationId = response.headers.get('x-correlation-id') ?? undefined;
+
+    if (!response.ok) {
+      let errorName = response.statusText;
+      let errorMessage: string | undefined;
+      let errorPath: string | undefined;
+      try {
+        const errorBody = (await response.json()) as Partial<ApiErrorEnvelope>;
+        errorName = errorBody.error ?? response.statusText;
+        errorMessage = errorBody.message;
+        errorPath = errorBody.path;
+      } catch {
+        // non-JSON error body — use status text only
+      }
+      logger.error({
+        method: 'GET',
+        url: safeUrl,
+        status: response.status,
+        durationMs: Date.now() - start,
+        correlationId,
+      });
+      throw new HttpError(
+        response.status,
+        errorName,
+        errorMessage,
+        errorPath,
+        correlationId
+      );
+    }
+
+    logger.debug({
+      method: 'GET',
+      url: safeUrl,
+      status: response.status,
+      durationMs: Date.now() - start,
+      correlationId,
+      data: '[Blob]',
+    });
+
+    return response.blob();
+  }
+
   post<T, B>(endpoint: string, body: B, config?: RequestConfig): Promise<T> {
     return this.execute<T>('POST', endpoint, body, config);
   }

--- a/src/shared/http/http-client.ts
+++ b/src/shared/http/http-client.ts
@@ -2,6 +2,7 @@ import type { RequestConfig } from './types';
 
 export interface HttpClient {
   get<T>(endpoint: string, config?: RequestConfig): Promise<T>;
+  getBlob(endpoint: string, config?: RequestConfig): Promise<Blob>;
   post<T, B>(endpoint: string, body: B, config?: RequestConfig): Promise<T>;
   postFormData<T>(
     endpoint: string,


### PR DESCRIPTION
## Summary
- **server-only guards**: add `import 'server-only'` to `auth/mutations.ts` and `auth/queries.ts` (was on `session.ts` only)
- **HTTP seam**: add `HttpClient.getBlob()` + `FetchHttpClient` implementation; replace raw `fetch` in `uploadAvatar` (user/mutations) with `apiClient.postFormData` and in `exportCvPdf` (cv/mutations) with
  `apiClient.getBlob` — all HTTP calls now go through the seam
- **ActionResult consolidation**: extend `shared/action-result.ts` with `'conflict'` and `'validation'` codes + unmapped-HttpError handling; delete ~220 lines of duplicate boilerplate from cv, user, ats, grammar, and features actions — all now import from
  `@/shared/action-result`
- **Tests**: add 13 new co-located tests across `user/data/mappers`, `user/data/mutations`, `ats/data/actions`, `grammar/data/actions` covering the exact files that were highest-risk
- **OAuth fragment**: call `history.replaceState` immediately after reading the URL hash to scrub tokens from the address bar before the async persist call; add comment pointing to the backend fix needed

## Test plan
- [ ] All 190 unit tests pass (`pnpm test:ci`)
- [ ] Avatar upload works end-to-end in settings
- [ ] PDF export works from the CV editor
- [ ] ATS scorer returns results and handles errors gracefully
- [ ] Grammar check inline functions in the CV editor
- [ ] Admin feature flag refresh button works
- [ ] OAuth login (Google/LinkedIn) completes and redirects to dashboard